### PR TITLE
feat: build main dashboard page layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,88 @@
+import { AgentCard } from "@/components/AgentCard";
+import ActivityLog from "@/components/ActivityLog";
+import { mockAgents, mockPRs, mockActivityLog } from "@/data/mockData";
+
 export default function Home() {
+  const totalAgents = mockAgents.length;
+  const activeAgents = mockAgents.filter((a) => a.status === "working").length;
+  const errorAgents = mockAgents.filter((a) => a.status === "error").length;
+  const prsOpen = mockPRs.filter((p) => p.mergeState === "open").length;
+  const prsMerged = mockPRs.filter((p) => p.mergeState === "merged").length;
+  const ciPassing = mockPRs.filter((p) => p.ciStatus === "passing").length;
+
+  const stats = [
+    { label: "Total Agents", value: totalAgents, color: "text-white" },
+    { label: "Active", value: activeAgents, color: "text-blue-400" },
+    { label: "Errors", value: errorAgents, color: "text-red-400" },
+    { label: "PRs Open", value: prsOpen, color: "text-yellow-400" },
+    { label: "PRs Merged", value: prsMerged, color: "text-purple-400" },
+    { label: "CI Passing", value: ciPassing, color: "text-green-400" },
+  ];
+
+  // Map mock activity events to the shape ActivityLog expects
+  const activityEvents = mockActivityLog.map((evt) => ({
+    id: evt.id,
+    timestamp: evt.timestamp,
+    agentName: evt.agentName,
+    eventType: evt.eventType as import("@/components/ActivityLog").EventType,
+    description: evt.description,
+  }));
+
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <h1 className="text-4xl font-bold">Fleet Dashboard</h1>
-      <p className="mt-4 text-lg text-gray-400">
-        Real-time fleet monitoring
-      </p>
+    <main className="min-h-screen bg-gray-950 text-white">
+      {/* Header */}
+      <header className="border-b border-white/10 bg-gray-900/80 backdrop-blur-sm">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8">
+          <div className="flex items-center gap-3">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-600">
+              <span className="text-sm font-bold">F</span>
+            </div>
+            <h1 className="text-xl font-bold tracking-tight">Fleet Dashboard</h1>
+          </div>
+          <p className="text-sm text-white/50">Real-time fleet monitoring</p>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8 space-y-6">
+        {/* Stats Bar */}
+        <section
+          aria-label="Dashboard statistics"
+          className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6"
+        >
+          {stats.map((stat) => (
+            <div
+              key={stat.label}
+              className="rounded-xl border border-white/10 bg-white/5 p-4 text-center"
+            >
+              <p className={`text-2xl font-bold ${stat.color}`}>{stat.value}</p>
+              <p className="mt-1 text-xs text-white/50">{stat.label}</p>
+            </div>
+          ))}
+        </section>
+
+        {/* Agent Cards Grid */}
+        <section aria-label="Agent cards">
+          <h2 className="mb-4 text-lg font-semibold text-gray-100">Agents</h2>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {mockAgents.map((agent) => (
+              <AgentCard
+                key={agent.sessionId}
+                agentName={agent.name}
+                status={agent.status}
+                issueTitle={agent.issue.title}
+                branchName={agent.branch}
+                timeElapsed={agent.timeElapsed}
+                prUrl={agent.pr?.url}
+              />
+            ))}
+          </div>
+        </section>
+
+        {/* Activity Log */}
+        <section aria-label="Activity log">
+          <ActivityLog events={activityEvents} maxHeight="max-h-[32rem]" />
+        </section>
+      </div>
     </main>
   );
 }

--- a/src/components/ActivityLog.tsx
+++ b/src/components/ActivityLog.tsx
@@ -1,4 +1,4 @@
-export type EventType = "commit" | "pr_created" | "ci_failed" | "review" | "deploy";
+export type EventType = "commit" | "pr_created" | "ci_failed" | "ci_passed" | "review" | "deploy" | "error";
 
 export interface AgentEvent {
   id: string;
@@ -33,6 +33,16 @@ const eventTypeConfig: Record<EventType, { label: string; color: string; dot: st
     label: "Deploy",
     color: "bg-orange-500/20 text-orange-400 border-orange-500/40",
     dot: "bg-orange-500",
+  },
+  ci_passed: {
+    label: "CI Passed",
+    color: "bg-green-500/20 text-green-400 border-green-500/40",
+    dot: "bg-green-500",
+  },
+  error: {
+    label: "Error",
+    color: "bg-red-500/20 text-red-400 border-red-500/40",
+    dot: "bg-red-500",
   },
 };
 


### PR DESCRIPTION
## Summary
- Builds the full dashboard page layout with header, stats bar, responsive AgentCard grid (3/2/1 columns), and ActivityLog section
- Extends ActivityLog component to support `ci_passed` and `error` event types from mock data
- Uses Tailwind CSS dark theme styling throughout

Closes #6

## Test plan
- [x] All 50 existing tests pass (`npx vitest run`)
- [ ] Verify responsive grid: 3 columns on large screens, 2 on medium, 1 on small
- [ ] Verify stats bar shows correct counts from mock data
- [ ] Verify ActivityLog renders all 20 mock events with proper badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)