### PR TITLE
Fix: install deps and add predev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Real-time fleet monitoring dashboard built with Next.js 15, TypeScript, and Tailwind CSS.
 
-## Getting Started
+## Setup
 
 ```bash
 npm install
@@ -11,8 +11,15 @@ npm run dev
 
 Open [http://localhost:3001](http://localhost:3001) in your browser.
 
-## Testing
+Running `npm run dev` automatically runs `npm install` first (via the `predev` script), so dependencies are always up to date.
 
-```bash
-npm test
-```
+## Available Scripts
+
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Start development server (port 3001) |
+| `npm run build` | Create production build |
+| `npm start` | Start production server (port 3001) |
+| `npm test` | Run tests with Vitest |
+| `npm run test:watch` | Run tests in watch mode |
+| `npm run lint` | Lint with ESLint |

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "npm install",
     "dev": "next dev --port 3001 --turbopack",
     "build": "next build",
     "start": "next start --port 3001",


### PR DESCRIPTION
## Summary
- Ran `npm install` to install all project dependencies (fixes dev server startup failure)
- Added `"predev": "npm install"` script to `package.json` so deps are always installed before `npm run dev`
- Updated `README.md` with setup instructions and available scripts table

Closes #17

## Verification
- Dev server starts successfully on port 3001
- All 72 tests pass (`npx vitest run`)
- Note: `npm run build` has a pre-existing type error in `src/app/api/dashboard/route.ts` (exported helper `transformAOResponse` not valid as a Route export) — not related to this issue

## Test plan
- [ ] Clone repo fresh, run `npm run dev`, confirm server starts on port 3001
- [ ] Confirm `npm test` passes all tests
- [ ] Confirm `predev` script triggers `npm install` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)