### PR TITLE
feat: agent status cards on dashboard homepage

### DIFF
--- a/src/__tests__/AgentStatusCards.test.tsx
+++ b/src/__tests__/AgentStatusCards.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import AgentStatusCards from "@/components/AgentStatusCards";
+import type { SessionsResponse } from "@/types/sessions";
+
+const mockSessions: SessionsResponse = {
+  sessions: [
+    { name: "agent-1", status: "working", branch: "feat/login", uptime: "2h 15m" },
+    { name: "agent-2", status: "idle", branch: "main", uptime: "45m" },
+    { name: "agent-3", status: "stuck", branch: "fix/crash", uptime: "1d 3h" },
+  ],
+};
+
+function mockFetchSuccess(data: SessionsResponse) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function mockFetchError(message = "Network error") {
+  global.fetch = vi.fn().mockRejectedValue(new Error(message));
+}
+
+describe("AgentStatusCards", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("shows loading skeletons initially", () => {
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    render(<AgentStatusCards />);
+    expect(screen.getAllByTestId("skeleton-card")).toHaveLength(3);
+  });
+
+  it("renders session cards after successful fetch", async () => {
+    mockFetchSuccess(mockSessions);
+    render(<AgentStatusCards />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("session-card")).toHaveLength(3);
+    });
+
+    expect(screen.getByText("agent-1")).toBeInTheDocument();
+    expect(screen.getByText("agent-2")).toBeInTheDocument();
+    expect(screen.getByText("agent-3")).toBeInTheDocument();
+  });
+
+  it("renders correct status badges", async () => {
+    mockFetchSuccess(mockSessions);
+    render(<AgentStatusCards />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("session-status-badge")).toHaveLength(3);
+    });
+
+    const badges = screen.getAllByTestId("session-status-badge");
+    expect(badges[0]).toHaveTextContent("Working");
+    expect(badges[1]).toHaveTextContent("Idle");
+    expect(badges[2]).toHaveTextContent("Stuck");
+  });
+
+  it("renders branch names", async () => {
+    mockFetchSuccess(mockSessions);
+    render(<AgentStatusCards />);
+
+    await waitFor(() => {
+      expect(screen.getByText("feat/login")).toBeInTheDocument();
+    });
+    expect(screen.getByText("main")).toBeInTheDocument();
+    expect(screen.getByText("fix/crash")).toBeInTheDocument();
+  });
+
+  it("renders uptime values", async () => {
+    mockFetchSuccess(mockSessions);
+    render(<AgentStatusCards />);
+
+    await waitFor(() => {
+      expect(screen.getByText("2h 15m")).toBeInTheDocument();
+    });
+    expect(screen.getByText("45m")).toBeInTheDocument();
+    expect(screen.getByText("1d 3h")).toBeInTheDocument();
+  });
+
+  it("shows error state when fetch fails", async () => {
+    mockFetchError("Network error");
+    render(<AgentStatusCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sessions-error")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Network error")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no sessions", async () => {
+    mockFetchSuccess({ sessions: [] });
+    render(<AgentStatusCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sessions-empty")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText("No active tmux sessions found.")
+    ).toBeInTheDocument();
+  });
+
+  it("shows API error with empty sessions", async () => {
+    mockFetchSuccess({ sessions: [], error: "tmux is not running" });
+    render(<AgentStatusCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sessions-error")).toBeInTheDocument();
+    });
+    expect(screen.getByText("tmux is not running")).toBeInTheDocument();
+  });
+
+  it("sets up auto-refresh interval", () => {
+    const setIntervalSpy = vi.spyOn(global, "setInterval");
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    render(<AgentStatusCards />);
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 10000);
+  });
+
+  it("shows warning banner when error exists but sessions are present", async () => {
+    mockFetchSuccess({
+      sessions: [
+        { name: "agent-1", status: "working", branch: "main", uptime: "1h" },
+      ],
+      error: "partial error",
+    });
+    render(<AgentStatusCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session-card")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("sessions-warning")).toBeInTheDocument();
+    expect(screen.getByText("partial error")).toBeInTheDocument();
+  });
+
+  it("handles non-ok HTTP responses", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    });
+    render(<AgentStatusCards />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("sessions-error")).toBeInTheDocument();
+    });
+    expect(screen.getByText("HTTP 500")).toBeInTheDocument();
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import RecentPRs from "@/components/RecentPRs";
 import { ConnectionIndicator } from "@/components/ConnectionIndicator";
 import { LoadingSkeleton } from "@/components/LoadingSkeleton";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import AgentStatusCards from "@/components/AgentStatusCards";
 import { useDashboardData } from "@/hooks/useDashboardData";
 
 export default function Home() {
@@ -125,6 +126,9 @@ export default function Home() {
               </div>
             ))}
           </section>
+
+          {/* Agent Sessions (tmux) */}
+          <AgentStatusCards />
 
           {/* Agent Cards Grid */}
           <section aria-label="Agent cards">

--- a/src/components/AgentStatusCards.tsx
+++ b/src/components/AgentStatusCards.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import type { TmuxSession, SessionsResponse } from "@/types/sessions";
+
+const STATUS_CONFIG = {
+  working: {
+    label: "Working",
+    dotClass: "bg-green-500",
+    badgeClass:
+      "bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20",
+  },
+  idle: {
+    label: "Idle",
+    dotClass: "bg-yellow-500",
+    badgeClass:
+      "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 border-yellow-500/20",
+  },
+  stuck: {
+    label: "Stuck",
+    dotClass: "bg-red-500",
+    badgeClass:
+      "bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20",
+  },
+} as const;
+
+function StatusBadge({ status }: { status: TmuxSession["status"] }) {
+  const config = STATUS_CONFIG[status];
+  return (
+    <span
+      data-testid="session-status-badge"
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium ${config.badgeClass}`}
+    >
+      <span
+        className={`inline-block h-2 w-2 rounded-full ${config.dotClass}`}
+        aria-hidden="true"
+      />
+      {config.label}
+    </span>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <div
+      data-testid="skeleton-card"
+      className="animate-pulse rounded-xl border border-gray-200 bg-white p-5 dark:border-white/10 dark:bg-white/5"
+    >
+      <div className="flex items-center justify-between">
+        <div className="h-5 w-28 rounded bg-gray-200 dark:bg-white/10" />
+        <div className="h-5 w-16 rounded-full bg-gray-200 dark:bg-white/10" />
+      </div>
+      <div className="mt-4 space-y-2">
+        <div className="h-4 w-40 rounded bg-gray-200 dark:bg-white/10" />
+        <div className="h-4 w-20 rounded bg-gray-200 dark:bg-white/10" />
+      </div>
+    </div>
+  );
+}
+
+export default function AgentStatusCards() {
+  const [sessions, setSessions] = useState<TmuxSession[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchSessions = useCallback(async () => {
+    try {
+      const res = await fetch("/api/sessions");
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data: SessionsResponse = await res.json();
+      if (data.error) {
+        setError(data.error);
+        setSessions(data.sessions);
+      } else {
+        setError(null);
+        setSessions(data.sessions);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch sessions");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSessions();
+    const interval = setInterval(fetchSessions, 10000);
+    return () => clearInterval(interval);
+  }, [fetchSessions]);
+
+  if (isLoading) {
+    return (
+      <section aria-label="Agent sessions loading">
+        <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Agent Sessions
+        </h2>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <SkeletonCard key={i} />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (error && sessions.length === 0) {
+    return (
+      <section aria-label="Agent sessions">
+        <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Agent Sessions
+        </h2>
+        <div
+          data-testid="sessions-error"
+          className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-6 text-center text-sm text-red-500 dark:text-red-400"
+          role="alert"
+        >
+          {error}
+        </div>
+      </section>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <section aria-label="Agent sessions">
+        <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
+          Agent Sessions
+        </h2>
+        <div
+          data-testid="sessions-empty"
+          className="rounded-xl border border-gray-200 bg-white px-4 py-6 text-center text-sm text-gray-500 dark:border-white/10 dark:bg-white/5 dark:text-white/50"
+        >
+          No active tmux sessions found.
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section aria-label="Agent sessions">
+      <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
+        Agent Sessions
+      </h2>
+      {error && (
+        <div
+          data-testid="sessions-warning"
+          className="mb-4 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-2 text-xs text-yellow-600 dark:text-yellow-400"
+          role="alert"
+        >
+          {error}
+        </div>
+      )}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {sessions.map((session) => (
+          <div
+            key={session.name}
+            data-testid="session-card"
+            className="rounded-xl border border-gray-200 bg-white p-5 transition-shadow hover:shadow-md dark:border-white/10 dark:bg-white/5"
+          >
+            <div className="flex items-center justify-between">
+              <h3
+                className="truncate text-sm font-semibold text-gray-900 dark:text-white"
+                title={session.name}
+              >
+                {session.name}
+              </h3>
+              <StatusBadge status={session.status} />
+            </div>
+            <div className="mt-3 space-y-1.5">
+              <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-white/50">
+                <svg
+                  className="h-3.5 w-3.5 flex-shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M13 10V3L4 14h7v7l9-11h-7z"
+                  />
+                </svg>
+                <span data-testid="session-branch" className="truncate" title={session.branch}>
+                  {session.branch}
+                </span>
+              </div>
+              <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-white/50">
+                <svg
+                  className="h-3.5 w-3.5 flex-shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <span data-testid="session-uptime">{session.uptime}</span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `AgentStatusCards` client component that fetches `/api/sessions` and renders a responsive grid (3 cols lg, 2 md, 1 sm) of tmux session cards
- Each card displays agent name, color-coded status badge (green=working, yellow=idle, red=stuck), current branch, and uptime
- Auto-refreshes every 10 seconds with loading skeleton and error/empty states
- Integrated into dashboard homepage above the existing Agent Cards section

## Test plan
- [x] 11 unit tests added covering: loading skeletons, card rendering, status badges, branch/uptime display, error state, empty state, API error, auto-refresh interval, warning banner, HTTP error handling
- [x] All 139 tests pass (`npx vitest run`)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)