### PR TITLE
Fix test failures from stale imports

### DIFF
--- a/src/__tests__/api-sessions-edge-cases.test.ts
+++ b/src/__tests__/api-sessions-edge-cases.test.ts
@@ -7,12 +7,12 @@ vi.mock("@/lib/execAsync", () => ({
 }));
 
 import {
-  GET,
   parseTmuxList,
   determineStatus,
   extractBranch,
   computeUptime,
-} from "@/app/api/sessions/route";
+} from "@/lib/sessionHelpers";
+import { GET } from "@/app/api/sessions/route";
 
 beforeEach(() => {
   mockExecAsync.mockReset();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,11 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./src/__tests__/setup.ts"],
+    exclude: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/.claude/worktrees/**",
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Updated `src/__tests__/api-sessions-edge-cases.test.ts` to import `parseTmuxList`, `computeUptime`, `determineStatus`, and `extractBranch` from `@/lib/sessionHelpers` instead of `@/app/api/sessions/route` (PR #33 moved them, PR #34 tests still referenced the old location)
- Added `.claude/worktrees/**` to vitest exclude list to prevent test duplication from worktree directories
- All 214 tests pass, 0 failures

## Test plan
- [x] `npx vitest run --dir src` passes with 214 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)