### PR TITLE
feat: add PWA support for mobile install

### DIFF
--- a/public/icons/icon-192x192.svg
+++ b/public/icons/icon-192x192.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="192" height="192">
+  <rect width="192" height="192" rx="32" fill="#0a0a0a"/>
+  <g transform="translate(96,96)">
+    <!-- Outer ring: fleet orbit -->
+    <circle cx="0" cy="0" r="60" fill="none" stroke="#3b82f6" stroke-width="4" stroke-dasharray="12 8" opacity="0.5"/>
+    <!-- Central hub -->
+    <circle cx="0" cy="0" r="20" fill="#3b82f6"/>
+    <circle cx="0" cy="0" r="10" fill="#0a0a0a"/>
+    <circle cx="0" cy="0" r="5" fill="#22d3ee"/>
+    <!-- Agent nodes -->
+    <circle cx="0" cy="-60" r="10" fill="#22d3ee"/>
+    <circle cx="52" cy="30" r="10" fill="#22d3ee"/>
+    <circle cx="-52" cy="30" r="10" fill="#22d3ee"/>
+    <!-- Connection lines -->
+    <line x1="0" y1="-20" x2="0" y2="-50" stroke="#3b82f6" stroke-width="2" opacity="0.7"/>
+    <line x1="17" y1="10" x2="42" y2="24" stroke="#3b82f6" stroke-width="2" opacity="0.7"/>
+    <line x1="-17" y1="10" x2="-42" y2="24" stroke="#3b82f6" stroke-width="2" opacity="0.7"/>
+  </g>
+</svg>

--- a/public/icons/icon-512x512.svg
+++ b/public/icons/icon-512x512.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="80" fill="#0a0a0a"/>
+  <g transform="translate(256,256)">
+    <!-- Outer ring: fleet orbit -->
+    <circle cx="0" cy="0" r="160" fill="none" stroke="#3b82f6" stroke-width="6" stroke-dasharray="20 12" opacity="0.5"/>
+    <!-- Central hub -->
+    <circle cx="0" cy="0" r="52" fill="#3b82f6"/>
+    <circle cx="0" cy="0" r="28" fill="#0a0a0a"/>
+    <circle cx="0" cy="0" r="14" fill="#22d3ee"/>
+    <!-- Agent nodes -->
+    <circle cx="0" cy="-160" r="26" fill="#22d3ee"/>
+    <circle cx="139" cy="80" r="26" fill="#22d3ee"/>
+    <circle cx="-139" cy="80" r="26" fill="#22d3ee"/>
+    <!-- Connection lines -->
+    <line x1="0" y1="-52" x2="0" y2="-134" stroke="#3b82f6" stroke-width="4" opacity="0.7"/>
+    <line x1="45" y1="26" x2="115" y2="64" stroke="#3b82f6" stroke-width="4" opacity="0.7"/>
+    <line x1="-45" y1="26" x2="-115" y2="64" stroke="#3b82f6" stroke-width="4" opacity="0.7"/>
+  </g>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,24 @@
+{
+  "name": "Agent Fleet Dashboard",
+  "short_name": "Fleet",
+  "description": "Real-time agent fleet monitoring dashboard",
+  "start_url": "/",
+  "display": "standalone",
+  "orientation": "portrait-primary",
+  "theme_color": "#0a0a0a",
+  "background_color": "#0a0a0a",
+  "icons": [
+    {
+      "src": "/icons/icon-192x192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icons/icon-512x512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,72 @@
+const CACHE_NAME = "fleet-dashboard-v1";
+
+const APP_SHELL_URLS = [
+  "/",
+  "/offline",
+];
+
+// Install: pre-cache the app shell
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL_URLS))
+  );
+  self.skipWaiting();
+});
+
+// Activate: clean up old caches
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+// Fetch: network-first for everything, cache fallback for navigation only
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+
+  // Never cache API requests — they must always be fresh
+  if (request.url.includes("/api/")) {
+    return;
+  }
+
+  // For navigation requests (HTML pages): network-first, fall back to cache, then offline page
+  if (request.mode === "navigate") {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          // Cache successful navigation responses for offline use
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          return response;
+        })
+        .catch(() =>
+          caches
+            .match(request)
+            .then((cached) => cached || caches.match("/offline"))
+        )
+    );
+    return;
+  }
+
+  // For static assets (JS, CSS, images): stale-while-revalidate
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      const networkFetch = fetch(request)
+        .then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          return response;
+        })
+        .catch(() => cached);
+
+      return cached || networkFetch;
+    })
+  );
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,21 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
+import { ServiceWorkerRegistrar } from "@/components/ServiceWorkerRegistrar";
 
 export const metadata: Metadata = {
   title: "Fleet Dashboard",
   description: "Real-time fleet monitoring dashboard",
+  manifest: "/manifest.json",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "black-translucent",
+    title: "Fleet",
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#0a0a0a",
 };
 
 export default function RootLayout({
@@ -14,8 +25,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <link rel="apple-touch-icon" href="/icons/icon-192x192.svg" />
+      </head>
       <body className="antialiased">
         <ThemeProvider>{children}</ThemeProvider>
+        <ServiceWorkerRegistrar />
       </body>
     </html>
   );

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+export default function OfflinePage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-[#0a0a0a] text-white">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        className="h-16 w-16 text-gray-500"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z"
+        />
+      </svg>
+      <h1 className="text-2xl font-bold">You are offline</h1>
+      <p className="text-gray-400">
+        The Fleet Dashboard requires a network connection to display real-time
+        agent data.
+      </p>
+      <button
+        onClick={() => window.location.reload()}
+        className="mt-4 rounded-lg bg-blue-600 px-6 py-2 font-medium text-white transition hover:bg-blue-500"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/src/components/ServiceWorkerRegistrar.tsx
+++ b/src/components/ServiceWorkerRegistrar.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ServiceWorkerRegistrar() {
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker
+        .register("/sw.js")
+        .then((registration) => {
+          console.log("SW registered, scope:", registration.scope);
+        })
+        .catch((err) => {
+          console.error("SW registration failed:", err);
+        });
+    }
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Added  with app name, dark theme colors, standalone display mode, and SVG icons
- Created 192x192 and 512x512 SVG icons at  (fleet hub + agent nodes design)
- Added manual service worker () that caches the app shell for offline access and shows a fallback page when offline, while never caching API responses
- Created  route with a retry button
- Wired manifest link, theme-color viewport, apple-web-app meta tags, and service worker registration into the root layout via a  client component
- No third-party dependencies added (no next-pwa)

## Test plan
- [ ] Run  and open in Chrome
- [ ] Verify "Install app" prompt appears in browser address bar
- [ ] Install on Android/iOS home screen and confirm standalone mode
- [ ] Disconnect network and verify offline fallback page renders
- [ ] Confirm API calls are never served from cache (always fresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)