### PR TITLE
feat: add agent health timeline with sparklines

### DIFF
--- a/src/__tests__/HealthSparkline.test.tsx
+++ b/src/__tests__/HealthSparkline.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { HealthSparkline } from "@/components/HealthSparkline";
+import type { HealthTimelineEntry } from "@/types/dashboard";
+
+const mockTimeline: HealthTimelineEntry[] = [
+  { timestamp: "2026-03-23T08:00:00Z", status: "working" },
+  { timestamp: "2026-03-23T08:30:00Z", status: "idle" },
+  { timestamp: "2026-03-23T09:00:00Z", status: "error" },
+  { timestamp: "2026-03-23T09:30:00Z", status: "working" },
+];
+
+describe("HealthSparkline", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders sparkline with bars", () => {
+    render(<HealthSparkline timeline={mockTimeline} />);
+    const sparkline = screen.getByTestId("health-sparkline");
+    expect(sparkline).toBeInTheDocument();
+    const svg = sparkline.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+    const rects = svg!.querySelectorAll("rect");
+    expect(rects).toHaveLength(4);
+  });
+
+  it("uses correct colors for each status", () => {
+    render(<HealthSparkline timeline={mockTimeline} />);
+    const svg = screen.getByTestId("health-sparkline").querySelector("svg")!;
+    const rects = svg.querySelectorAll("rect");
+    expect(rects[0]).toHaveAttribute("fill", "#22c55e"); // working = green
+    expect(rects[1]).toHaveAttribute("fill", "#eab308"); // idle = yellow
+    expect(rects[2]).toHaveAttribute("fill", "#ef4444"); // error = red
+    expect(rects[3]).toHaveAttribute("fill", "#22c55e"); // working = green
+  });
+
+  it("calls onClick when clicked", () => {
+    const handleClick = vi.fn();
+    render(<HealthSparkline timeline={mockTimeline} onClick={handleClick} />);
+    fireEvent.click(screen.getByTestId("health-sparkline"));
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
+  it("returns null for empty timeline", () => {
+    const { container } = render(<HealthSparkline timeline={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/__tests__/HealthTimelineModal.test.tsx
+++ b/src/__tests__/HealthTimelineModal.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { HealthTimelineModal } from "@/components/HealthTimelineModal";
+import type { HealthTimelineEntry } from "@/types/dashboard";
+
+const mockTimeline: HealthTimelineEntry[] = [
+  { timestamp: "2026-03-23T08:00:00Z", status: "working" },
+  { timestamp: "2026-03-23T08:30:00Z", status: "idle" },
+  { timestamp: "2026-03-23T09:00:00Z", status: "error" },
+  { timestamp: "2026-03-23T09:30:00Z", status: "working" },
+];
+
+describe("HealthTimelineModal", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders modal with agent name", () => {
+    render(
+      <HealthTimelineModal
+        agentName="agent-alpha"
+        timeline={mockTimeline}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText("agent-alpha — Health Timeline (24h)"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows status counts in legend", () => {
+    render(
+      <HealthTimelineModal
+        agentName="agent-alpha"
+        timeline={mockTimeline}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Working:")).toBeInTheDocument();
+    expect(screen.getByText("Idle:")).toBeInTheDocument();
+    expect(screen.getByText("Error:")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <HealthTimelineModal
+        agentName="agent-alpha"
+        timeline={mockTimeline}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Close timeline"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <HealthTimelineModal
+        agentName="agent-alpha"
+        timeline={mockTimeline}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("health-timeline-modal"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when Escape key is pressed", () => {
+    const onClose = vi.fn();
+    render(
+      <HealthTimelineModal
+        agentName="agent-alpha"
+        timeline={mockTimeline}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -145,6 +145,7 @@ export default function Home() {
                   branchName={agent.branch}
                   timeElapsed={agent.timeElapsed}
                   prUrl={agent.pr?.url}
+                  healthTimeline={agent.healthTimeline}
                 />
               ))}
             </div>

--- a/src/components/AgentCard.tsx
+++ b/src/components/AgentCard.tsx
@@ -1,3 +1,10 @@
+"use client";
+
+import { useState } from "react";
+import type { HealthTimelineEntry } from "@/types/dashboard";
+import { HealthSparkline } from "./HealthSparkline";
+import { HealthTimelineModal } from "./HealthTimelineModal";
+
 export type AgentStatus =
   | "working"
   | "pr_open"
@@ -13,6 +20,7 @@ export interface AgentCardProps {
   branchName: string;
   timeElapsed: string;
   prUrl?: string;
+  healthTimeline?: HealthTimelineEntry[];
 }
 
 const statusConfig: Record<
@@ -58,46 +66,65 @@ export function AgentCard({
   branchName,
   timeElapsed,
   prUrl,
+  healthTimeline,
 }: AgentCardProps) {
   const { label, bgClass, textClass } = statusConfig[status];
+  const [showTimeline, setShowTimeline] = useState(false);
 
   return (
-    <div className="rounded-xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-white/5 p-4 space-y-3">
-      <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-white truncate">
-          {agentName}
-        </h3>
-        <span
-          data-testid="status-badge"
-          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${bgClass} ${textClass}`}
-        >
-          {label}
-        </span>
-      </div>
-
-      <p className="text-sm text-gray-600 dark:text-white/70 truncate" title={issueTitle}>
-        {issueTitle}
-      </p>
-
-      <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-white/50">
-        <code className="rounded bg-gray-200 dark:bg-white/10 px-1.5 py-0.5 font-mono truncate">
-          {branchName}
-        </code>
-      </div>
-
-      <div className="flex items-center justify-between text-xs text-gray-400 dark:text-white/40">
-        <span>{timeElapsed}</span>
-        {prUrl ? (
-          <a
-            href={prUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-400 hover:text-blue-300 underline"
+    <>
+      <div className="rounded-xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-white/5 p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+            {agentName}
+          </h3>
+          <span
+            data-testid="status-badge"
+            className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${bgClass} ${textClass}`}
           >
-            View PR
-          </a>
-        ) : null}
+            {label}
+          </span>
+        </div>
+
+        {healthTimeline && healthTimeline.length > 0 && (
+          <HealthSparkline
+            timeline={healthTimeline}
+            onClick={() => setShowTimeline(true)}
+          />
+        )}
+
+        <p className="text-sm text-gray-600 dark:text-white/70 truncate" title={issueTitle}>
+          {issueTitle}
+        </p>
+
+        <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-white/50">
+          <code className="rounded bg-gray-200 dark:bg-white/10 px-1.5 py-0.5 font-mono truncate">
+            {branchName}
+          </code>
+        </div>
+
+        <div className="flex items-center justify-between text-xs text-gray-400 dark:text-white/40">
+          <span>{timeElapsed}</span>
+          {prUrl ? (
+            <a
+              href={prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-400 hover:text-blue-300 underline"
+            >
+              View PR
+            </a>
+          ) : null}
+        </div>
       </div>
-    </div>
+
+      {showTimeline && healthTimeline && (
+        <HealthTimelineModal
+          agentName={agentName}
+          timeline={healthTimeline}
+          onClose={() => setShowTimeline(false)}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/HealthSparkline.tsx
+++ b/src/components/HealthSparkline.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useMemo } from "react";
+import type { HealthTimelineEntry, HealthStatus } from "@/types/dashboard";
+
+const STATUS_COLORS: Record<HealthStatus, string> = {
+  working: "#22c55e",
+  idle: "#eab308",
+  error: "#ef4444",
+};
+
+interface HealthSparklineProps {
+  timeline: HealthTimelineEntry[];
+  width?: number;
+  height?: number;
+  onClick?: () => void;
+}
+
+export function HealthSparkline({
+  timeline,
+  width = 160,
+  height = 24,
+  onClick,
+}: HealthSparklineProps) {
+  const bars = useMemo(() => {
+    if (timeline.length === 0) return [];
+    const barWidth = width / timeline.length;
+    return timeline.map((entry, i) => ({
+      x: i * barWidth,
+      width: Math.max(barWidth - 0.5, 1),
+      color: STATUS_COLORS[entry.status],
+      status: entry.status,
+      timestamp: entry.timestamp,
+    }));
+  }, [timeline, width]);
+
+  if (timeline.length === 0) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group w-full cursor-pointer rounded transition-opacity hover:opacity-80"
+      aria-label="View health timeline details"
+      data-testid="health-sparkline"
+    >
+      <svg
+        width="100%"
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label="Agent health over last 24 hours"
+      >
+        {bars.map((bar, i) => (
+          <rect
+            key={i}
+            x={bar.x}
+            y={0}
+            width={bar.width}
+            height={height}
+            fill={bar.color}
+            rx={1}
+            opacity={0.8}
+          />
+        ))}
+      </svg>
+    </button>
+  );
+}

--- a/src/components/HealthTimelineModal.tsx
+++ b/src/components/HealthTimelineModal.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+import type { HealthTimelineEntry, HealthStatus } from "@/types/dashboard";
+
+const STATUS_COLORS: Record<HealthStatus, string> = {
+  working: "#22c55e",
+  idle: "#eab308",
+  error: "#ef4444",
+};
+
+const STATUS_LABELS: Record<HealthStatus, string> = {
+  working: "Working",
+  idle: "Idle",
+  error: "Error",
+};
+
+interface HealthTimelineModalProps {
+  agentName: string;
+  timeline: HealthTimelineEntry[];
+  onClose: () => void;
+}
+
+export function HealthTimelineModal({
+  agentName,
+  timeline,
+  onClose,
+}: HealthTimelineModalProps) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  const barWidth = 100 / timeline.length;
+
+  const statusCounts = timeline.reduce(
+    (acc, entry) => {
+      acc[entry.status] = (acc[entry.status] || 0) + 1;
+      return acc;
+    },
+    {} as Record<HealthStatus, number>,
+  );
+
+  const formatTime = (timestamp: string) => {
+    const date = new Date(timestamp);
+    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={onClose}
+      data-testid="health-timeline-modal"
+    >
+      <div
+        className="mx-4 w-full max-w-2xl rounded-2xl border border-gray-200 bg-white dark:border-white/10 dark:bg-gray-900 p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            {agentName} — Health Timeline (24h)
+          </h2>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-white/10 dark:hover:text-white"
+            aria-label="Close timeline"
+          >
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Full-width timeline bar */}
+        <div className="mb-4 overflow-hidden rounded-lg">
+          <svg
+            width="100%"
+            height="48"
+            viewBox={`0 0 100 48`}
+            preserveAspectRatio="none"
+            role="img"
+            aria-label="Detailed agent health timeline"
+          >
+            {timeline.map((entry, i) => (
+              <rect
+                key={i}
+                x={`${i * barWidth}%`}
+                y={0}
+                width={`${Math.max(barWidth, 0.2)}%`}
+                height={48}
+                fill={STATUS_COLORS[entry.status]}
+                opacity={0.85}
+              />
+            ))}
+          </svg>
+        </div>
+
+        {/* Time axis */}
+        <div className="mb-6 flex justify-between text-xs text-gray-500 dark:text-white/50">
+          <span>{timeline.length > 0 ? formatTime(timeline[0].timestamp) : ""}</span>
+          <span>
+            {timeline.length > 0
+              ? formatTime(timeline[Math.floor(timeline.length / 2)].timestamp)
+              : ""}
+          </span>
+          <span>
+            {timeline.length > 0
+              ? formatTime(timeline[timeline.length - 1].timestamp)
+              : ""}
+          </span>
+        </div>
+
+        {/* Legend / Summary */}
+        <div className="flex gap-6">
+          {(["working", "idle", "error"] as HealthStatus[]).map((status) => (
+            <div key={status} className="flex items-center gap-2">
+              <div
+                className="h-3 w-3 rounded-sm"
+                style={{ backgroundColor: STATUS_COLORS[status] }}
+              />
+              <span className="text-sm text-gray-600 dark:text-white/70">
+                {STATUS_LABELS[status]}:{" "}
+                <span className="font-medium text-gray-900 dark:text-white">
+                  {statusCounts[status] || 0}
+                </span>
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -1,6 +1,32 @@
-import { Agent, PR, ActivityEvent, DashboardData } from "@/types/dashboard";
+import {
+  Agent,
+  PR,
+  ActivityEvent,
+  DashboardData,
+  HealthTimelineEntry,
+  HealthStatus,
+} from "@/types/dashboard";
 
 const REPO_URL = "https://github.com/sergi-izquierdo/fleet-dashboard";
+
+function generateHealthTimeline(
+  pattern: HealthStatus[],
+  hours: number = 24,
+  intervalMinutes: number = 30,
+): HealthTimelineEntry[] {
+  const now = new Date();
+  const entries: HealthTimelineEntry[] = [];
+  const totalPoints = Math.floor((hours * 60) / intervalMinutes);
+
+  for (let i = totalPoints - 1; i >= 0; i--) {
+    const timestamp = new Date(
+      now.getTime() - i * intervalMinutes * 60 * 1000,
+    );
+    const status = pattern[i % pattern.length];
+    entries.push({ timestamp: timestamp.toISOString(), status });
+  }
+  return entries;
+}
 
 export const mockAgents: Agent[] = [
   {
@@ -14,6 +40,14 @@ export const mockAgents: Agent[] = [
     },
     branch: "feat/issue-12-auth-flow",
     timeElapsed: "14m 32s",
+    healthTimeline: generateHealthTimeline([
+      "working",
+      "working",
+      "working",
+      "idle",
+      "working",
+      "working",
+    ]),
   },
   {
     name: "agent-beta",
@@ -30,6 +64,14 @@ export const mockAgents: Agent[] = [
       url: `${REPO_URL}/pull/21`,
       number: 21,
     },
+    healthTimeline: generateHealthTimeline([
+      "working",
+      "idle",
+      "idle",
+      "working",
+      "working",
+      "idle",
+    ]),
   },
   {
     name: "agent-gamma",
@@ -46,6 +88,14 @@ export const mockAgents: Agent[] = [
       url: `${REPO_URL}/pull/23`,
       number: 23,
     },
+    healthTimeline: generateHealthTimeline([
+      "working",
+      "working",
+      "working",
+      "working",
+      "working",
+      "idle",
+    ]),
   },
   {
     name: "agent-delta",
@@ -62,6 +112,14 @@ export const mockAgents: Agent[] = [
       url: `${REPO_URL}/pull/19`,
       number: 19,
     },
+    healthTimeline: generateHealthTimeline([
+      "working",
+      "working",
+      "idle",
+      "idle",
+      "idle",
+      "idle",
+    ]),
   },
   {
     name: "agent-epsilon",
@@ -74,6 +132,14 @@ export const mockAgents: Agent[] = [
     },
     branch: "feat/issue-22-pg-migration",
     timeElapsed: "8m 47s",
+    healthTimeline: generateHealthTimeline([
+      "working",
+      "error",
+      "error",
+      "working",
+      "error",
+      "idle",
+    ]),
   },
 ];
 

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,3 +1,10 @@
+export type HealthStatus = "working" | "idle" | "error";
+
+export interface HealthTimelineEntry {
+  timestamp: string;
+  status: HealthStatus;
+}
+
 export interface Agent {
   name: string;
   sessionId: string;
@@ -19,6 +26,7 @@ export interface Agent {
     url: string;
     number: number;
   };
+  healthTimeline?: HealthTimelineEntry[];
 }
 
 export interface PR {


### PR DESCRIPTION
Closes #42

## Summary
- Added mini sparkline charts to each agent card showing health activity over the last 24 hours
- Color-coded bars: green = working, yellow = idle, red = error
- Clicking a sparkline opens a full timeline modal with expanded view, time axis labels, and status count legend
- Pure SVG implementation — no external charting library needed

## Changes
- **`src/types/dashboard.ts`** — Added `HealthStatus`, `HealthTimelineEntry` types and optional `healthTimeline` field to `Agent`
- **`src/components/HealthSparkline.tsx`** — New component rendering an SVG bar chart sparkline
- **`src/components/HealthTimelineModal.tsx`** — New modal with expanded timeline, time axis, and status legend
- **`src/components/AgentCard.tsx`** — Integrated sparkline + modal; added `"use client"` and state management
- **`src/data/mockData.ts`** — Generated mock 24h health timeline data for each agent
- **`src/app/page.tsx`** — Passes `healthTimeline` prop to `AgentCard`

## Test plan
- [x] All 192 existing tests pass
- [x] New unit tests for `HealthSparkline` (4 tests: rendering, colors, click handler, empty state)
- [x] New unit tests for `HealthTimelineModal` (5 tests: rendering, legend, close button, backdrop click, Escape key)
- [x] `npm run build` succeeds