### PR TITLE
feat: notification center with bell icon

### DIFF
--- a/src/__tests__/NotificationCenter.test.tsx
+++ b/src/__tests__/NotificationCenter.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi, beforeEach } from "vitest";
+import { NotificationCenter } from "@/components/NotificationCenter";
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+});
+
+describe("NotificationCenter", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("renders the bell icon button", () => {
+    render(<NotificationCenter />);
+    expect(screen.getByTestId("notification-bell")).toBeInTheDocument();
+  });
+
+  it("shows unread badge when there are unread notifications", async () => {
+    render(<NotificationCenter />);
+    // Advance timers to let demo notifications be seeded
+    vi.advanceTimersByTime(100);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("notification-badge")).toBeInTheDocument();
+    });
+  });
+
+  it("opens dropdown when bell is clicked", async () => {
+    render(<NotificationCenter />);
+    vi.advanceTimersByTime(100);
+
+    const bell = screen.getByTestId("notification-bell");
+    fireEvent.click(bell);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("notification-dropdown")).toBeInTheDocument();
+    });
+  });
+
+  it("closes dropdown when bell is clicked again", async () => {
+    render(<NotificationCenter />);
+    vi.advanceTimersByTime(100);
+
+    const bell = screen.getByTestId("notification-bell");
+    fireEvent.click(bell);
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("notification-dropdown")).toBeInTheDocument();
+    });
+
+    fireEvent.click(bell);
+    expect(screen.queryByTestId("notification-dropdown")).not.toBeInTheDocument();
+  });
+
+  it("closes dropdown on Escape key", async () => {
+    render(<NotificationCenter />);
+    vi.advanceTimersByTime(100);
+
+    fireEvent.click(screen.getByTestId("notification-bell"));
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("notification-dropdown")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByTestId("notification-dropdown")).not.toBeInTheDocument();
+  });
+
+  it("shows notification list in dropdown", async () => {
+    render(<NotificationCenter />);
+    vi.advanceTimersByTime(100);
+
+    fireEvent.click(screen.getByTestId("notification-bell"));
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("notification-list")).toBeInTheDocument();
+    });
+  });
+
+  it("has mark all read button when there are unread notifications", async () => {
+    render(<NotificationCenter />);
+    vi.advanceTimersByTime(100);
+
+    fireEvent.click(screen.getByTestId("notification-bell"));
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("mark-all-read")).toBeInTheDocument();
+    });
+  });
+
+  it("marks all as read when clicking mark all read", async () => {
+    render(<NotificationCenter />);
+    vi.advanceTimersByTime(100);
+
+    fireEvent.click(screen.getByTestId("notification-bell"));
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("mark-all-read")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("mark-all-read"));
+
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId("mark-all-read")).not.toBeInTheDocument();
+    });
+  });
+
+  it("clears all notifications when clicking clear all", async () => {
+    render(<NotificationCenter />);
+    vi.advanceTimersByTime(100);
+
+    fireEvent.click(screen.getByTestId("notification-bell"));
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("clear-all")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("clear-all"));
+
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId("clear-all")).not.toBeInTheDocument();
+      expect(screen.getByText("No notifications")).toBeInTheDocument();
+    });
+  });
+
+  it("has correct aria-label with unread count", async () => {
+    render(<NotificationCenter />);
+    vi.advanceTimersByTime(100);
+
+    await vi.waitFor(() => {
+      const bell = screen.getByTestId("notification-bell");
+      expect(bell.getAttribute("aria-label")).toMatch(/unread/);
+    });
+  });
+
+  it("persists notifications to localStorage", async () => {
+    render(<NotificationCenter />);
+    vi.advanceTimersByTime(100);
+
+    await vi.waitFor(() => {
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "fleet-dashboard-notifications",
+        expect.any(String),
+      );
+    });
+  });
+});

--- a/src/__tests__/useNotifications.test.ts
+++ b/src/__tests__/useNotifications.test.ts
@@ -1,0 +1,203 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useNotifications } from "@/hooks/useNotifications";
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+});
+
+describe("useNotifications", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it("starts with empty notifications", () => {
+    const { result } = renderHook(() => useNotifications());
+    expect(result.current.notifications).toEqual([]);
+    expect(result.current.unreadCount).toBe(0);
+  });
+
+  it("adds a notification", () => {
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.addNotification({
+        title: "Test notification",
+        description: "Test description",
+        eventType: "ci_failed",
+        agentName: "agent-1",
+      });
+    });
+
+    expect(result.current.notifications).toHaveLength(1);
+    expect(result.current.notifications[0].title).toBe("Test notification");
+    expect(result.current.notifications[0].severity).toBe("error");
+    expect(result.current.notifications[0].read).toBe(false);
+    expect(result.current.unreadCount).toBe(1);
+  });
+
+  it("marks a notification as read", () => {
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.addNotification({
+        title: "Test",
+        description: "Desc",
+        eventType: "pr_merged",
+      });
+    });
+
+    const id = result.current.notifications[0].id;
+
+    act(() => {
+      result.current.markAsRead(id);
+    });
+
+    expect(result.current.notifications[0].read).toBe(true);
+    expect(result.current.unreadCount).toBe(0);
+  });
+
+  it("marks all as read", () => {
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.addNotification({
+        title: "Test 1",
+        description: "Desc",
+        eventType: "ci_failed",
+      });
+      result.current.addNotification({
+        title: "Test 2",
+        description: "Desc",
+        eventType: "pr_merged",
+      });
+    });
+
+    act(() => {
+      result.current.markAllAsRead();
+    });
+
+    expect(result.current.unreadCount).toBe(0);
+    expect(result.current.notifications.every((n) => n.read)).toBe(true);
+  });
+
+  it("dismisses a notification", () => {
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.addNotification({
+        title: "Test",
+        description: "Desc",
+        eventType: "deploy",
+      });
+    });
+
+    const id = result.current.notifications[0].id;
+
+    act(() => {
+      result.current.dismiss(id);
+    });
+
+    expect(result.current.notifications).toHaveLength(0);
+  });
+
+  it("clears all notifications", () => {
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.addNotification({
+        title: "Test 1",
+        description: "Desc",
+        eventType: "ci_failed",
+      });
+      result.current.addNotification({
+        title: "Test 2",
+        description: "Desc",
+        eventType: "pr_merged",
+      });
+    });
+
+    act(() => {
+      result.current.clearAll();
+    });
+
+    expect(result.current.notifications).toHaveLength(0);
+  });
+
+  it("maps event types to correct severity", () => {
+    const { result } = renderHook(() => useNotifications());
+
+    const testCases = [
+      { eventType: "pr_merged" as const, expectedSeverity: "success" },
+      { eventType: "ci_failed" as const, expectedSeverity: "error" },
+      { eventType: "agent_stuck" as const, expectedSeverity: "warning" },
+      { eventType: "deploy" as const, expectedSeverity: "info" },
+    ];
+
+    for (const { eventType, expectedSeverity } of testCases) {
+      act(() => {
+        result.current.addNotification({
+          title: `Test ${eventType}`,
+          description: "Desc",
+          eventType,
+        });
+      });
+
+      expect(result.current.notifications[0].severity).toBe(expectedSeverity);
+
+      act(() => {
+        result.current.clearAll();
+      });
+    }
+  });
+
+  it("persists to localStorage", () => {
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      result.current.addNotification({
+        title: "Persisted",
+        description: "Should be saved",
+        eventType: "ci_passed",
+      });
+    });
+
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      "fleet-dashboard-notifications",
+      expect.any(String),
+    );
+  });
+
+  it("limits notifications to MAX_NOTIFICATIONS", () => {
+    const { result } = renderHook(() => useNotifications());
+
+    act(() => {
+      for (let i = 0; i < 55; i++) {
+        result.current.addNotification({
+          title: `Notification ${i}`,
+          description: "Desc",
+          eventType: "commit" as never,
+        });
+      }
+    });
+
+    expect(result.current.notifications.length).toBeLessThanOrEqual(50);
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import RecentPRs from "@/components/RecentPRs";
 import { ConnectionIndicator } from "@/components/ConnectionIndicator";
 import { LoadingSkeleton } from "@/components/LoadingSkeleton";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { NotificationCenter } from "@/components/NotificationCenter";
 import AgentStatusCards from "@/components/AgentStatusCards";
 import { useDashboardData } from "@/hooks/useDashboardData";
 
@@ -73,6 +74,7 @@ export default function Home() {
           </div>
           <div className="flex items-center gap-4">
             <ThemeToggle />
+            <NotificationCenter />
             <ConnectionIndicator status={connectionStatus} />
             <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-white/50">
               <span data-testid="countdown">

--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import type { Notification } from "@/types/notifications";
+import { severityConfig, eventTypeLabels } from "@/types/notifications";
+import { useNotifications } from "@/hooks/useNotifications";
+
+function formatTimestamp(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60000);
+
+  if (diffMin < 1) return "Just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+}
+
+function NotificationItem({
+  notification,
+  onMarkAsRead,
+  onDismiss,
+}: {
+  notification: Notification;
+  onMarkAsRead: (id: string) => void;
+  onDismiss: (id: string) => void;
+}) {
+  const config = severityConfig[notification.severity];
+
+  return (
+    <div
+      className={`group relative flex gap-3 p-3 transition-colors ${
+        notification.read
+          ? "opacity-60"
+          : "bg-gray-50 dark:bg-white/5"
+      }`}
+      data-testid={`notification-item-${notification.id}`}
+    >
+      <div className="flex-shrink-0 pt-0.5">
+        <span
+          className={`inline-block h-2.5 w-2.5 rounded-full ${config.dot}`}
+          aria-hidden="true"
+        />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                {notification.title}
+              </span>
+              <span
+                className={`inline-flex items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${config.badge}`}
+              >
+                {eventTypeLabels[notification.eventType]}
+              </span>
+            </div>
+            <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400 truncate">
+              {notification.description}
+            </p>
+            <div className="mt-1 flex items-center gap-2">
+              {notification.agentName && (
+                <span className="text-[10px] text-gray-400 dark:text-gray-500">
+                  {notification.agentName}
+                </span>
+              )}
+              <time
+                className="text-[10px] text-gray-400 dark:text-gray-500"
+                dateTime={notification.timestamp}
+              >
+                {formatTimestamp(notification.timestamp)}
+              </time>
+            </div>
+          </div>
+          <div className="flex flex-shrink-0 items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+            {!notification.read && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onMarkAsRead(notification.id);
+                }}
+                className="rounded p-1 text-gray-400 hover:bg-gray-200 dark:hover:bg-white/10 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                aria-label="Mark as read"
+                title="Mark as read"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                  className="h-3.5 w-3.5"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </button>
+            )}
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDismiss(notification.id);
+              }}
+              className="rounded p-1 text-gray-400 hover:bg-gray-200 dark:hover:bg-white/10 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+              aria-label="Dismiss notification"
+              title="Dismiss"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="h-3.5 w-3.5"
+              >
+                <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function NotificationCenter() {
+  const {
+    notifications,
+    unreadCount,
+    isLoaded,
+    addNotification,
+    markAsRead,
+    markAllAsRead,
+    dismiss,
+    clearAll,
+  } = useNotifications();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Seed demo notifications on first visit
+  useEffect(() => {
+    if (isLoaded && notifications.length === 0) {
+      const demoEvents: Parameters<typeof addNotification>[0][] = [
+        {
+          title: "PR #42 merged",
+          description: "feat: add dark mode toggle merged into main",
+          eventType: "pr_merged",
+          agentName: "agent-alpha",
+        },
+        {
+          title: "CI failed on PR #38",
+          description: "Test suite failed: 3 tests failing in auth module",
+          eventType: "ci_failed",
+          agentName: "agent-beta",
+        },
+        {
+          title: "Agent gamma unresponsive",
+          description: "No heartbeat received for 5 minutes",
+          eventType: "agent_stuck",
+          agentName: "agent-gamma",
+        },
+        {
+          title: "Deployed to staging",
+          description: "v2.1.0 deployed successfully to staging environment",
+          eventType: "deploy",
+          agentName: "agent-alpha",
+        },
+        {
+          title: "Review requested",
+          description: "PR #45 needs your review: fix: resolve login timeout",
+          eventType: "review_requested",
+          agentName: "agent-delta",
+        },
+      ];
+      // Add in reverse order so first item appears at top
+      for (let i = demoEvents.length - 1; i >= 0; i--) {
+        setTimeout(() => addNotification(demoEvents[i]), (demoEvents.length - i) * 10);
+      }
+    }
+  }, [isLoaded, notifications.length, addNotification]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () =>
+        document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [isOpen]);
+
+  // Close on Escape key
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [isOpen]);
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      {/* Bell Button */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="relative rounded-md border border-gray-300 dark:border-white/20 p-1.5 text-gray-600 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-white/10 hover:text-gray-900 dark:hover:text-white transition-colors"
+        aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ""}`}
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+        data-testid="notification-bell"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="h-4 w-4"
+        >
+          <path
+            fillRule="evenodd"
+            d="M5.25 9a6.75 6.75 0 0113.5 0v.75c0 2.123.8 4.057 2.118 5.52a.75.75 0 01-.297 1.206c-1.544.57-3.16.99-4.831 1.243a3.75 3.75 0 11-7.48 0 24.585 24.585 0 01-4.831-1.244.75.75 0 01-.298-1.205A8.217 8.217 0 005.25 9.75V9zm4.502 8.9a2.25 2.25 0 004.496 0 25.057 25.057 0 01-4.496 0z"
+            clipRule="evenodd"
+          />
+        </svg>
+
+        {/* Unread Badge */}
+        {unreadCount > 0 && (
+          <span
+            className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white"
+            data-testid="notification-badge"
+          >
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {/* Dropdown */}
+      {isOpen && (
+        <div
+          className="absolute right-0 top-full z-50 mt-2 w-80 sm:w-96 rounded-xl border border-gray-200 dark:border-white/10 bg-white dark:bg-gray-900 shadow-lg shadow-black/10 dark:shadow-black/30"
+          role="menu"
+          data-testid="notification-dropdown"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-gray-200 dark:border-white/10 px-4 py-3">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              Notifications
+            </h3>
+            <div className="flex items-center gap-2">
+              {unreadCount > 0 && (
+                <button
+                  onClick={markAllAsRead}
+                  className="text-xs text-blue-500 hover:text-blue-400 transition-colors"
+                  data-testid="mark-all-read"
+                >
+                  Mark all read
+                </button>
+              )}
+              {notifications.length > 0 && (
+                <button
+                  onClick={clearAll}
+                  className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                  data-testid="clear-all"
+                >
+                  Clear all
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* Notification List */}
+          <div
+            className="max-h-96 overflow-y-auto divide-y divide-gray-100 dark:divide-white/5"
+            data-testid="notification-list"
+          >
+            {notifications.length === 0 ? (
+              <div className="py-8 text-center">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="mx-auto h-8 w-8 text-gray-300 dark:text-gray-600"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M5.25 9a6.75 6.75 0 0113.5 0v.75c0 2.123.8 4.057 2.118 5.52a.75.75 0 01-.297 1.206c-1.544.57-3.16.99-4.831 1.243a3.75 3.75 0 11-7.48 0 24.585 24.585 0 01-4.831-1.244.75.75 0 01-.298-1.205A8.217 8.217 0 005.25 9.75V9zm4.502 8.9a2.25 2.25 0 004.496 0 25.057 25.057 0 01-4.496 0z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+                <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                  No notifications
+                </p>
+              </div>
+            ) : (
+              notifications.map((notification) => (
+                <NotificationItem
+                  key={notification.id}
+                  notification={notification}
+                  onMarkAsRead={markAsRead}
+                  onDismiss={dismiss}
+                />
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState, useCallback, useSyncExternalStore } from "react";
+import type { Notification, NotificationEventType } from "@/types/notifications";
+import { eventTypeToSeverity } from "@/types/notifications";
+
+const STORAGE_KEY = "fleet-dashboard-notifications";
+const MAX_NOTIFICATIONS = 50;
+
+function loadNotifications(): Notification[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveNotifications(notifications: Notification[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(notifications));
+  } catch {
+    // localStorage full or unavailable
+  }
+}
+
+const subscribe = () => () => {};
+
+export function useNotifications() {
+  const isLoaded = useSyncExternalStore(subscribe, () => true, () => false);
+
+  const [notifications, setNotifications] = useState<Notification[]>(loadNotifications);
+
+  const updateNotifications = useCallback((updater: (prev: Notification[]) => Notification[]) => {
+    setNotifications((prev) => {
+      const next = updater(prev);
+      saveNotifications(next);
+      return next;
+    });
+  }, []);
+
+  const addNotification = useCallback(
+    (params: {
+      title: string;
+      description: string;
+      eventType: NotificationEventType;
+      agentName?: string;
+    }) => {
+      const notification: Notification = {
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+        title: params.title,
+        description: params.description,
+        eventType: params.eventType,
+        severity: eventTypeToSeverity[params.eventType],
+        timestamp: new Date().toISOString(),
+        read: false,
+        agentName: params.agentName,
+      };
+
+      updateNotifications((prev) => [notification, ...prev].slice(0, MAX_NOTIFICATIONS));
+    },
+    [updateNotifications],
+  );
+
+  const markAsRead = useCallback((id: string) => {
+    updateNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, read: true } : n)),
+    );
+  }, [updateNotifications]);
+
+  const markAllAsRead = useCallback(() => {
+    updateNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+  }, [updateNotifications]);
+
+  const dismiss = useCallback((id: string) => {
+    updateNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, [updateNotifications]);
+
+  const clearAll = useCallback(() => {
+    updateNotifications(() => []);
+  }, [updateNotifications]);
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  return {
+    notifications,
+    unreadCount,
+    isLoaded,
+    addNotification,
+    markAsRead,
+    markAllAsRead,
+    dismiss,
+    clearAll,
+  };
+}

--- a/src/types/notifications.ts
+++ b/src/types/notifications.ts
@@ -1,0 +1,67 @@
+export type NotificationSeverity = "info" | "warning" | "error" | "success";
+
+export type NotificationEventType =
+  | "pr_merged"
+  | "ci_failed"
+  | "ci_passed"
+  | "agent_stuck"
+  | "review_requested"
+  | "deploy"
+  | "error";
+
+export interface Notification {
+  id: string;
+  title: string;
+  description: string;
+  eventType: NotificationEventType;
+  severity: NotificationSeverity;
+  timestamp: string;
+  read: boolean;
+  agentName?: string;
+}
+
+export const severityConfig: Record<
+  NotificationSeverity,
+  { color: string; dot: string; badge: string }
+> = {
+  info: {
+    color: "text-blue-400",
+    dot: "bg-blue-500",
+    badge: "bg-blue-500/20 text-blue-400 border-blue-500/40",
+  },
+  success: {
+    color: "text-green-400",
+    dot: "bg-green-500",
+    badge: "bg-green-500/20 text-green-400 border-green-500/40",
+  },
+  warning: {
+    color: "text-yellow-400",
+    dot: "bg-yellow-500",
+    badge: "bg-yellow-500/20 text-yellow-400 border-yellow-500/40",
+  },
+  error: {
+    color: "text-red-400",
+    dot: "bg-red-500",
+    badge: "bg-red-500/20 text-red-400 border-red-500/40",
+  },
+};
+
+export const eventTypeToSeverity: Record<NotificationEventType, NotificationSeverity> = {
+  pr_merged: "success",
+  ci_passed: "success",
+  deploy: "info",
+  review_requested: "info",
+  ci_failed: "error",
+  agent_stuck: "warning",
+  error: "error",
+};
+
+export const eventTypeLabels: Record<NotificationEventType, string> = {
+  pr_merged: "PR Merged",
+  ci_failed: "CI Failed",
+  ci_passed: "CI Passed",
+  agent_stuck: "Agent Stuck",
+  review_requested: "Review Requested",
+  deploy: "Deploy",
+  error: "Error",
+};


### PR DESCRIPTION
## Summary

Closes #43

- **Bell icon** in the header with an unread count badge (red circle with count)
- **Dropdown panel** showing recent events: PR merged, CI failed, agent stuck, review requested, deploy, etc.
- **Mark as read / dismiss** individual notifications (hover to reveal actions)
- **Mark all read / clear all** bulk actions in the dropdown header
- **Severity color coding**: info (blue), success (green), warning (yellow), error (red)
- **localStorage persistence** — notifications survive page reloads
- **Keyboard accessible** — closes on Escape, proper aria attributes
- Demo notifications seeded on first visit for discoverability

## New files
- `src/types/notifications.ts` — Notification type, severity config, event type mappings
- `src/hooks/useNotifications.ts` — Hook managing notification state with localStorage sync
- `src/components/NotificationCenter.tsx` — Bell button + dropdown UI component
- `src/__tests__/NotificationCenter.test.tsx` — Component tests
- `src/__tests__/useNotifications.test.ts` — Hook unit tests

## Test plan
- [x] `npm run build` passes
- [x] All 203 tests pass (`npx vitest run`)
- [ ] Verify bell icon appears in header between theme toggle and connection indicator
- [ ] Click bell to open/close dropdown
- [ ] Verify unread badge shows correct count
- [ ] Hover notification to see mark-as-read and dismiss buttons
- [ ] Mark all read / clear all work correctly
- [ ] Notifications persist after page reload
- [ ] Severity colors match event types
- [ ] Dropdown closes on outside click and Escape key