### PR TITLE
feat: real-time agent terminal viewer

### DIFF
--- a/src/__tests__/TerminalViewer.test.tsx
+++ b/src/__tests__/TerminalViewer.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, cleanup, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import TerminalViewer from "@/components/TerminalViewer";
+
+const mockTerminalResponse = {
+  sessionName: "agent-1",
+  output: "$ npm test\nPASSED all tests\nerror: something failed\nwarning: deprecated\n```js\nconsole.log('hello');\n```\n",
+};
+
+function mockFetchSuccess(data = mockTerminalResponse) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function mockFetchError() {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        sessionName: "agent-1",
+        output: "",
+        error: "Session \"agent-1\" not found",
+      }),
+  });
+}
+
+describe("TerminalViewer", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    document.body.style.overflow = "";
+  });
+
+  it("renders with session name in header", async () => {
+    mockFetchSuccess();
+    render(<TerminalViewer sessionName="agent-1" onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("terminal-session-name")).toHaveTextContent(
+      "agent-1"
+    );
+  });
+
+  it("shows loading state initially", () => {
+    global.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+    render(<TerminalViewer sessionName="agent-1" onClose={vi.fn()} />);
+
+    expect(
+      screen.getByText("Loading terminal output...")
+    ).toBeInTheDocument();
+  });
+
+  it("renders terminal output after fetch", async () => {
+    mockFetchSuccess();
+    render(<TerminalViewer sessionName="agent-1" onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal-output")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/npm test/)).toBeInTheDocument();
+  });
+
+  it("shows error state when fetch returns error", async () => {
+    mockFetchError();
+    render(<TerminalViewer sessionName="agent-1" onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal-error")).toBeInTheDocument();
+    });
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    mockFetchSuccess();
+    const onClose = vi.fn();
+    render(<TerminalViewer sessionName="agent-1" onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId("terminal-close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose on Escape key", async () => {
+    mockFetchSuccess();
+    const onClose = vi.fn();
+    render(<TerminalViewer sessionName="agent-1" onClose={onClose} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("toggles scroll lock button", async () => {
+    mockFetchSuccess();
+    render(<TerminalViewer sessionName="agent-1" onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scroll-lock-toggle")).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByTestId("scroll-lock-toggle");
+    expect(toggle).toHaveTextContent("Auto-scroll");
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveTextContent("Scroll locked");
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveTextContent("Auto-scroll");
+  });
+
+  it("prevents body scroll when open", () => {
+    mockFetchSuccess();
+    render(<TerminalViewer sessionName="agent-1" onClose={vi.fn()} />);
+    expect(document.body.style.overflow).toBe("hidden");
+  });
+
+  it("restores body scroll on unmount", () => {
+    mockFetchSuccess();
+    const { unmount } = render(
+      <TerminalViewer sessionName="agent-1" onClose={vi.fn()} />
+    );
+    unmount();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("applies syntax highlighting to error lines", async () => {
+    mockFetchSuccess();
+    render(<TerminalViewer sessionName="agent-1" onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal-output")).toBeInTheDocument();
+    });
+
+    const output = screen.getByTestId("terminal-output");
+    const errorSpan = output.querySelector(".text-red-400");
+    expect(errorSpan).not.toBeNull();
+  });
+
+  it("encodes session name in API URL", async () => {
+    mockFetchSuccess();
+    render(
+      <TerminalViewer sessionName="agent with spaces" onClose={vi.fn()} />
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/sessions/agent%20with%20spaces/terminal"
+      );
+    });
+  });
+
+  it("sets up auto-refresh interval", () => {
+    const setIntervalSpy = vi.spyOn(global, "setInterval");
+    mockFetchSuccess();
+    render(<TerminalViewer sessionName="agent-1" onClose={vi.fn()} />);
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 3000);
+  });
+
+  it("has fullscreen dialog role", () => {
+    mockFetchSuccess();
+    render(<TerminalViewer sessionName="agent-1" onClose={vi.fn()} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/src/app/api/sessions/[name]/terminal/route.ts
+++ b/src/app/api/sessions/[name]/terminal/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { execFileAsync } from "@/lib/execFileAsync";
+
+interface TerminalResponse {
+  sessionName: string;
+  output: string;
+  error?: string;
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  const { name: sessionName } = await params;
+
+  try {
+    const { stdout } = await execFileAsync("tmux", [
+      "capture-pane",
+      "-t",
+      sessionName,
+      "-p",
+      "-S",
+      "-500",
+    ]);
+
+    const response: TerminalResponse = {
+      sessionName,
+      output: stdout,
+    };
+    return NextResponse.json(response, { status: 200 });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown error";
+
+    const isNotFound =
+      message.includes("can't find") ||
+      message.includes("no server running") ||
+      message.includes("session not found");
+
+    const response: TerminalResponse = {
+      sessionName,
+      output: "",
+      error: isNotFound
+        ? `Session "${sessionName}" not found`
+        : `Failed to read terminal: ${message}`,
+    };
+
+    return NextResponse.json(response, {
+      status: isNotFound ? 404 : 500,
+    });
+  }
+}

--- a/src/components/AgentCard.tsx
+++ b/src/components/AgentCard.tsx
@@ -21,6 +21,7 @@ export interface AgentCardProps {
   timeElapsed: string;
   prUrl?: string;
   healthTimeline?: HealthTimelineEntry[];
+  onViewTerminal?: () => void;
 }
 
 const statusConfig: Record<
@@ -73,13 +74,31 @@ export function AgentCard({
   timeElapsed,
   prUrl,
   healthTimeline,
+  onViewTerminal,
 }: AgentCardProps) {
   const { label, bgClass, textClass, dotClass } = statusConfig[status];
   const [showTimeline, setShowTimeline] = useState(false);
 
   return (
     <>
-      <div className="rounded-xl border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 p-4 space-y-3 transition-all duration-200 hover:shadow-md hover:-translate-y-0.5 dark:hover:border-white/20 dark:hover:bg-white/[0.07]">
+      <div
+        className={`rounded-xl border border-gray-200 dark:border-white/10 bg-white dark:bg-white/5 p-4 space-y-3 transition-all duration-200 hover:shadow-md hover:-translate-y-0.5 dark:hover:border-white/20 dark:hover:bg-white/[0.07] ${
+          onViewTerminal ? "cursor-pointer" : ""
+        }`}
+        onClick={onViewTerminal}
+        role={onViewTerminal ? "button" : undefined}
+        tabIndex={onViewTerminal ? 0 : undefined}
+        onKeyDown={
+          onViewTerminal
+            ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onViewTerminal();
+                }
+              }
+            : undefined
+        }
+      >
         <div className="flex items-center justify-between">
           <h3 className="text-sm font-semibold text-gray-900 dark:text-white truncate">
             {agentName}
@@ -112,16 +131,38 @@ export function AgentCard({
 
         <div className="flex items-center justify-between text-xs text-gray-400 dark:text-white/40">
           <span>{timeElapsed}</span>
-          {prUrl ? (
-            <a
-              href={prUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-500 dark:text-blue-400 hover:text-blue-400 dark:hover:text-blue-300 underline transition-colors"
-            >
-              View PR
-            </a>
-          ) : null}
+          <div className="flex items-center gap-3">
+            {onViewTerminal && (
+              <span className="text-blue-500 dark:text-blue-400 flex items-center gap-1">
+                <svg
+                  className="h-3.5 w-3.5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                  />
+                </svg>
+                Terminal
+              </span>
+            )}
+            {prUrl ? (
+              <a
+                href={prUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-500 dark:text-blue-400 hover:text-blue-400 dark:hover:text-blue-300 underline transition-colors"
+                onClick={(e) => e.stopPropagation()}
+              >
+                View PR
+              </a>
+            ) : null}
+          </div>
         </div>
       </div>
 

--- a/src/components/AgentStatusCards.tsx
+++ b/src/components/AgentStatusCards.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import type { TmuxSession, SessionsResponse } from "@/types/sessions";
+import TerminalViewer from "@/components/TerminalViewer";
 
 const STATUS_CONFIG = {
   working: {
@@ -62,6 +63,7 @@ export default function AgentStatusCards() {
   const [sessions, setSessions] = useState<TmuxSession[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [selectedSession, setSelectedSession] = useState<string | null>(null);
 
   const fetchSessions = useCallback(async () => {
     try {
@@ -154,10 +156,11 @@ export default function AgentStatusCards() {
       )}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 stagger-children">
         {sessions.map((session) => (
-          <div
+          <button
             key={session.name}
             data-testid="session-card"
-            className="rounded-xl border border-gray-200 bg-white p-5 transition-all duration-200 hover:shadow-md hover:-translate-y-0.5 dark:border-white/10 dark:bg-white/5 dark:hover:border-white/20 dark:hover:bg-white/[0.07]"
+            onClick={() => setSelectedSession(session.name)}
+            className="rounded-xl border border-gray-200 bg-white p-5 text-left transition-all duration-200 hover:shadow-md hover:-translate-y-0.5 hover:border-blue-400/50 dark:border-white/10 dark:bg-white/5 dark:hover:border-white/20 dark:hover:bg-white/[0.07] cursor-pointer"
           >
             <div className="flex items-center justify-between">
               <h3
@@ -206,9 +209,33 @@ export default function AgentStatusCards() {
                 <span data-testid="session-uptime">{session.uptime}</span>
               </div>
             </div>
-          </div>
+            <div className="mt-3 flex items-center gap-1 text-xs text-blue-500 dark:text-blue-400">
+              <svg
+                className="h-3.5 w-3.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              <span>View terminal</span>
+            </div>
+          </button>
         ))}
       </div>
+
+      {selectedSession && (
+        <TerminalViewer
+          sessionName={selectedSession}
+          onClose={() => setSelectedSession(null)}
+        />
+      )}
     </section>
   );
 }

--- a/src/components/TerminalViewer.tsx
+++ b/src/components/TerminalViewer.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useEffect, useState, useRef, useCallback } from "react";
+
+interface TerminalViewerProps {
+  sessionName: string;
+  onClose: () => void;
+}
+
+interface TerminalResponse {
+  sessionName: string;
+  output: string;
+  error?: string;
+}
+
+/** Minimal ANSI-strip: remove escape sequences so we render plain text. */
+function stripAnsi(text: string): string {
+  return text.replace(/\u001b\[[0-9;]*[a-zA-Z]/g, "");
+}
+
+/**
+ * Highlight lines that look like code-block fences, errors, prompts, etc.
+ * Returns an array of React elements for each line.
+ */
+function highlightLines(output: string) {
+  const lines = output.split("\n");
+  return lines.map((raw, i) => {
+    const line = stripAnsi(raw);
+
+    // Error lines
+    if (/error[:\s]/i.test(line) || /fatal:/i.test(line) || /ENOENT/.test(line)) {
+      return (
+        <span key={i} className="text-red-400">
+          {line}
+          {"\n"}
+        </span>
+      );
+    }
+
+    // Warning lines
+    if (/warn(ing)?[:\s]/i.test(line)) {
+      return (
+        <span key={i} className="text-yellow-400">
+          {line}
+          {"\n"}
+        </span>
+      );
+    }
+
+    // Success / passing
+    if (/pass(ed|ing)?/i.test(line) || /success/i.test(line) || /✓/.test(line)) {
+      return (
+        <span key={i} className="text-green-400">
+          {line}
+          {"\n"}
+        </span>
+      );
+    }
+
+    // Shell prompts ($ or >)
+    if (/^\s*[\$#>]/.test(line)) {
+      return (
+        <span key={i} className="text-blue-400">
+          {line}
+          {"\n"}
+        </span>
+      );
+    }
+
+    // Code-block fences
+    if (/^```/.test(line.trim())) {
+      return (
+        <span key={i} className="text-purple-400">
+          {line}
+          {"\n"}
+        </span>
+      );
+    }
+
+    // Git diff + / -
+    if (/^\+[^+]/.test(line)) {
+      return (
+        <span key={i} className="text-green-400">
+          {line}
+          {"\n"}
+        </span>
+      );
+    }
+    if (/^-[^-]/.test(line)) {
+      return (
+        <span key={i} className="text-red-400">
+          {line}
+          {"\n"}
+        </span>
+      );
+    }
+
+    return (
+      <span key={i}>
+        {line}
+        {"\n"}
+      </span>
+    );
+  });
+}
+
+export default function TerminalViewer({
+  sessionName,
+  onClose,
+}: TerminalViewerProps) {
+  const [output, setOutput] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [scrollLock, setScrollLock] = useState(false);
+  const terminalRef = useRef<HTMLPreElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const scrollToBottom = useCallback(() => {
+    if (!scrollLock && terminalRef.current) {
+      terminalRef.current.scrollTop = terminalRef.current.scrollHeight;
+    }
+  }, [scrollLock]);
+
+  const fetchTerminal = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/sessions/${encodeURIComponent(sessionName)}/terminal`
+      );
+      const data: TerminalResponse = await res.json();
+      if (data.error) {
+        setError(data.error);
+      } else {
+        setError(null);
+        setOutput(data.output);
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to fetch terminal"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [sessionName]);
+
+  // Initial fetch + polling
+  useEffect(() => {
+    fetchTerminal();
+    const interval = setInterval(fetchTerminal, 3000);
+    return () => clearInterval(interval);
+  }, [fetchTerminal]);
+
+  // Auto-scroll when output changes
+  useEffect(() => {
+    scrollToBottom();
+  }, [output, scrollToBottom]);
+
+  // Close on Escape key
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  // Prevent body scroll when modal is open
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="fixed inset-0 z-50 flex flex-col bg-gray-950/95 backdrop-blur-sm"
+      role="dialog"
+      aria-label={`Terminal output for ${sessionName}`}
+      data-testid="terminal-viewer"
+    >
+      {/* Header bar */}
+      <div className="flex items-center justify-between border-b border-white/10 bg-gray-900 px-4 py-3">
+        <div className="flex items-center gap-3 min-w-0">
+          {/* Terminal icon */}
+          <svg
+            className="h-4 w-4 flex-shrink-0 text-green-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+          <h2
+            className="text-sm font-semibold text-white truncate"
+            data-testid="terminal-session-name"
+          >
+            {sessionName}
+          </h2>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {/* Scroll lock toggle */}
+          <button
+            onClick={() => setScrollLock(!scrollLock)}
+            className={`rounded-md border px-2.5 py-1 text-xs transition-colors ${
+              scrollLock
+                ? "border-yellow-500/50 bg-yellow-500/20 text-yellow-400"
+                : "border-white/20 text-white/70 hover:bg-white/10 hover:text-white"
+            }`}
+            title={scrollLock ? "Auto-scroll paused" : "Auto-scroll active"}
+            data-testid="scroll-lock-toggle"
+          >
+            {scrollLock ? "Scroll locked" : "Auto-scroll"}
+          </button>
+
+          {/* Close button */}
+          <button
+            onClick={onClose}
+            className="rounded-md border border-white/20 px-2.5 py-1 text-xs text-white/70 hover:bg-white/10 hover:text-white transition-colors"
+            aria-label="Close terminal viewer"
+            data-testid="terminal-close"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Terminal body */}
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center">
+          <div className="text-sm text-white/50">Loading terminal output...</div>
+        </div>
+      ) : error ? (
+        <div className="flex flex-1 items-center justify-center px-4">
+          <div
+            className="rounded-lg border border-red-500/30 bg-red-500/10 px-6 py-4 text-sm text-red-400"
+            role="alert"
+            data-testid="terminal-error"
+          >
+            {error}
+          </div>
+        </div>
+      ) : (
+        <pre
+          ref={terminalRef}
+          className="flex-1 overflow-auto p-4 font-mono text-xs leading-5 text-gray-300 sm:text-sm"
+          data-testid="terminal-output"
+        >
+          {highlightLines(output)}
+        </pre>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #39

- **New API endpoint** `/api/sessions/[name]/terminal` captures the last 500 lines of tmux pane output for a given session
- **TerminalViewer component** renders a fullscreen modal overlay with live terminal output, including:
  - Auto-scroll to bottom with scroll-lock toggle
  - Syntax highlighting for errors (red), warnings (yellow), success (green), shell prompts (blue), and diff lines
  - Mobile-friendly fullscreen layout
  - Escape key and close button to dismiss
  - Auto-refresh every 3 seconds
- **Clickable session cards** in AgentStatusCards open the terminal viewer for that session
- **Clickable agent cards** on the dashboard also open the terminal viewer via `sessionId`

## Test plan

- [x] All 196 existing tests pass
- [x] 13 new tests for TerminalViewer covering: render, loading, error state, close button, Escape key, scroll-lock toggle, body scroll lock, syntax highlighting, URL encoding, auto-refresh interval, dialog role
- [x] Build succeeds with no warnings
- [ ] Manual: click a session card → terminal viewer opens with live output
- [ ] Manual: click an agent card → terminal viewer opens
- [ ] Manual: toggle scroll lock → auto-scroll pauses/resumes
- [ ] Manual: press Escape → viewer closes
- [ ] Manual: verify mobile layout fills screen