### PR TITLE
feat: command palette with keyboard shortcuts

### DIFF
--- a/src/__tests__/CommandPalette.test.tsx
+++ b/src/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import {
+  CommandPalette,
+  buildCommandItems,
+  type CommandItem,
+} from "@/components/CommandPalette";
+import type { DashboardData } from "@/types/dashboard";
+
+const mockItems: CommandItem[] = [
+  {
+    id: "action-refresh",
+    label: "Refresh dashboard",
+    category: "action",
+    shortcut: "R",
+    icon: "↻",
+    onSelect: vi.fn(),
+  },
+  {
+    id: "action-theme",
+    label: "Toggle theme",
+    category: "action",
+    shortcut: "T",
+    icon: "◑",
+    onSelect: vi.fn(),
+  },
+  {
+    id: "nav-agents",
+    label: "Go to Agents",
+    category: "navigation",
+    icon: "🤖",
+    onSelect: vi.fn(),
+  },
+  {
+    id: "agent-1",
+    label: "Agent Alpha — Fix login bug",
+    category: "agent",
+    icon: "🤖",
+    onSelect: vi.fn(),
+  },
+  {
+    id: "pr-42",
+    label: "#42 Add dark mode support",
+    category: "pr",
+    icon: "🟢",
+    onSelect: vi.fn(),
+  },
+];
+
+describe("CommandPalette", () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing when closed", () => {
+    render(<CommandPalette open={false} onClose={onClose} items={mockItems} />);
+    expect(screen.queryByTestId("command-palette")).not.toBeInTheDocument();
+  });
+
+  it("renders the palette when open", () => {
+    render(<CommandPalette open={true} onClose={onClose} items={mockItems} />);
+    expect(screen.getByTestId("command-palette")).toBeInTheDocument();
+    expect(screen.getByTestId("command-palette-input")).toBeInTheDocument();
+  });
+
+  it("shows all items when no query is entered", () => {
+    render(<CommandPalette open={true} onClose={onClose} items={mockItems} />);
+    expect(screen.getByText("Refresh dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Toggle theme")).toBeInTheDocument();
+    expect(screen.getByText("Go to Agents")).toBeInTheDocument();
+    expect(screen.getByText("Agent Alpha — Fix login bug")).toBeInTheDocument();
+    expect(screen.getByText("#42 Add dark mode support")).toBeInTheDocument();
+  });
+
+  it("filters items with fuzzy search", () => {
+    render(<CommandPalette open={true} onClose={onClose} items={mockItems} />);
+    const input = screen.getByTestId("command-palette-input");
+
+    fireEvent.change(input, { target: { value: "refresh" } });
+
+    expect(screen.getByText("Refresh dashboard")).toBeInTheDocument();
+    expect(screen.queryByText("Toggle theme")).not.toBeInTheDocument();
+    expect(screen.queryByText("Go to Agents")).not.toBeInTheDocument();
+  });
+
+  it("shows no results message when nothing matches", () => {
+    render(<CommandPalette open={true} onClose={onClose} items={mockItems} />);
+    const input = screen.getByTestId("command-palette-input");
+
+    fireEvent.change(input, { target: { value: "zzzzzzz" } });
+
+    expect(screen.getByText("No results found")).toBeInTheDocument();
+  });
+
+  it("calls onClose when Escape is pressed", () => {
+    render(<CommandPalette open={true} onClose={onClose} items={mockItems} />);
+    const input = screen.getByTestId("command-palette-input");
+
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSelect and onClose when Enter is pressed on selected item", () => {
+    render(<CommandPalette open={true} onClose={onClose} items={mockItems} />);
+    const input = screen.getByTestId("command-palette-input");
+
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mockItems[0].onSelect).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("navigates items with arrow keys", () => {
+    render(<CommandPalette open={true} onClose={onClose} items={mockItems} />);
+    const input = screen.getByTestId("command-palette-input");
+
+    // Move down to second item
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mockItems[1].onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when backdrop is clicked", () => {
+    render(<CommandPalette open={true} onClose={onClose} items={mockItems} />);
+    const backdrop = screen.getByTestId("command-palette");
+
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close when palette body is clicked", () => {
+    render(<CommandPalette open={true} onClose={onClose} items={mockItems} />);
+    const input = screen.getByTestId("command-palette-input");
+
+    fireEvent.click(input);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("displays keyboard shortcuts", () => {
+    render(<CommandPalette open={true} onClose={onClose} items={mockItems} />);
+    const kbds = screen.getAllByRole("option");
+    // Verify shortcuts are rendered within kbd elements
+    const refreshItem = screen.getByTestId("command-item-action-refresh");
+    expect(refreshItem.querySelector("kbd")?.textContent).toBe("R");
+    const themeItem = screen.getByTestId("command-item-action-theme");
+    expect(themeItem.querySelector("kbd")?.textContent).toBe("T");
+  });
+});
+
+describe("buildCommandItems", () => {
+  const mockData: DashboardData = {
+    agents: [
+      {
+        name: "Agent-1",
+        sessionId: "s1",
+        status: "working",
+        issue: {
+          title: "Fix auth flow",
+          number: 10,
+          url: "https://github.com/test/repo/issues/10",
+        },
+        branch: "feat/auth",
+        timeElapsed: "2h",
+        pr: { url: "https://github.com/test/repo/pull/11", number: 11 },
+      },
+    ],
+    prs: [
+      {
+        number: 11,
+        url: "https://github.com/test/repo/pull/11",
+        title: "Fix auth flow",
+        ciStatus: "passing",
+        reviewStatus: "pending",
+        mergeState: "open",
+        author: "bot",
+        branch: "feat/auth",
+      },
+    ],
+    activityLog: [],
+  };
+
+  it("builds static action items", () => {
+    const items = buildCommandItems(null, {
+      refresh: vi.fn(),
+      toggleTheme: vi.fn(),
+      scrollToSection: vi.fn(),
+    });
+
+    const actionItems = items.filter((i) => i.category === "action");
+    expect(actionItems).toHaveLength(2);
+    expect(actionItems.map((i) => i.label)).toContain("Refresh dashboard");
+    expect(actionItems.map((i) => i.label)).toContain("Toggle theme");
+  });
+
+  it("builds navigation items", () => {
+    const items = buildCommandItems(null, {
+      refresh: vi.fn(),
+      toggleTheme: vi.fn(),
+      scrollToSection: vi.fn(),
+    });
+
+    const navItems = items.filter((i) => i.category === "navigation");
+    expect(navItems.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("includes agents from dashboard data", () => {
+    const items = buildCommandItems(mockData, {
+      refresh: vi.fn(),
+      toggleTheme: vi.fn(),
+      scrollToSection: vi.fn(),
+    });
+
+    const agentItems = items.filter((i) => i.category === "agent");
+    expect(agentItems).toHaveLength(1);
+    expect(agentItems[0].label).toContain("Agent-1");
+    expect(agentItems[0].label).toContain("Fix auth flow");
+  });
+
+  it("includes PRs from dashboard data", () => {
+    const items = buildCommandItems(mockData, {
+      refresh: vi.fn(),
+      toggleTheme: vi.fn(),
+      scrollToSection: vi.fn(),
+    });
+
+    const prItems = items.filter((i) => i.category === "pr");
+    expect(prItems).toHaveLength(1);
+    expect(prItems[0].label).toContain("#11");
+  });
+});

--- a/src/__tests__/fuzzyMatch.test.ts
+++ b/src/__tests__/fuzzyMatch.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { fuzzyMatch } from "@/lib/fuzzyMatch";
+
+describe("fuzzyMatch", () => {
+  it("matches empty query to anything", () => {
+    expect(fuzzyMatch("", "anything")).toEqual({ score: 0 });
+  });
+
+  it("matches exact substring", () => {
+    const result = fuzzyMatch("refresh", "Refresh dashboard");
+    expect(result).not.toBeNull();
+  });
+
+  it("matches fuzzy characters in order", () => {
+    const result = fuzzyMatch("rd", "Refresh dashboard");
+    expect(result).not.toBeNull();
+  });
+
+  it("returns null when characters are not in order", () => {
+    expect(fuzzyMatch("zyx", "Refresh dashboard")).toBeNull();
+  });
+
+  it("is case insensitive", () => {
+    const result = fuzzyMatch("REFRESH", "refresh dashboard");
+    expect(result).not.toBeNull();
+  });
+
+  it("scores consecutive matches better than spread matches", () => {
+    const consecutive = fuzzyMatch("ref", "refresh");
+    const spread = fuzzyMatch("ref", "r_e_f_resh");
+    expect(consecutive).not.toBeNull();
+    expect(spread).not.toBeNull();
+    expect(consecutive!.score).toBeLessThan(spread!.score);
+  });
+});

--- a/src/__tests__/useKeyboardShortcuts.test.ts
+++ b/src/__tests__/useKeyboardShortcuts.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+
+describe("useKeyboardShortcuts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function fireKey(
+    key: string,
+    opts: Partial<KeyboardEventInit> = {},
+    target?: HTMLElement,
+  ) {
+    const event = new KeyboardEvent("keydown", {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...opts,
+    });
+    (target ?? document).dispatchEvent(event);
+  }
+
+  it("opens command palette on Ctrl+K", () => {
+    const handlers = {
+      onToggleCommandPalette: vi.fn(),
+      onRefresh: vi.fn(),
+      onToggleTheme: vi.fn(),
+    };
+    const { unmount } = renderHook(() => useKeyboardShortcuts(handlers));
+    fireKey("k", { ctrlKey: true });
+    expect(handlers.onToggleCommandPalette).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("opens command palette on Meta+K", () => {
+    const handlers = {
+      onToggleCommandPalette: vi.fn(),
+      onRefresh: vi.fn(),
+      onToggleTheme: vi.fn(),
+    };
+    const { unmount } = renderHook(() => useKeyboardShortcuts(handlers));
+    fireKey("k", { metaKey: true });
+    expect(handlers.onToggleCommandPalette).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("refreshes on R key", () => {
+    const handlers = {
+      onToggleCommandPalette: vi.fn(),
+      onRefresh: vi.fn(),
+      onToggleTheme: vi.fn(),
+    };
+    const { unmount } = renderHook(() => useKeyboardShortcuts(handlers));
+    fireKey("r");
+    expect(handlers.onRefresh).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("toggles theme on T key", () => {
+    const handlers = {
+      onToggleCommandPalette: vi.fn(),
+      onRefresh: vi.fn(),
+      onToggleTheme: vi.fn(),
+    };
+    const { unmount } = renderHook(() => useKeyboardShortcuts(handlers));
+    fireKey("t");
+    expect(handlers.onToggleTheme).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("does not fire single-key shortcuts when typing in an input", () => {
+    const handlers = {
+      onToggleCommandPalette: vi.fn(),
+      onRefresh: vi.fn(),
+      onToggleTheme: vi.fn(),
+    };
+    const { unmount } = renderHook(() => useKeyboardShortcuts(handlers));
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    fireKey("r", {}, input);
+    fireKey("t", {}, input);
+
+    expect(handlers.onRefresh).not.toHaveBeenCalled();
+    expect(handlers.onToggleTheme).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+    unmount();
+  });
+
+  it("still opens palette with Ctrl+K even when focused on input", () => {
+    const handlers = {
+      onToggleCommandPalette: vi.fn(),
+      onRefresh: vi.fn(),
+      onToggleTheme: vi.fn(),
+    };
+    const { unmount } = renderHook(() => useKeyboardShortcuts(handlers));
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+
+    fireKey("k", { ctrlKey: true }, input);
+    expect(handlers.onToggleCommandPalette).toHaveBeenCalledTimes(1);
+
+    document.body.removeChild(input);
+    unmount();
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback, useMemo } from "react";
+import { useTheme } from "next-themes";
 import { AgentCard } from "@/components/AgentCard";
 import ActivityLog from "@/components/ActivityLog";
 import RecentPRs from "@/components/RecentPRs";
@@ -15,12 +16,19 @@ import { ToastContainer, showToast } from "@/components/Toast";
 import { BottomNav, type MobileTab } from "@/components/BottomNav";
 import { PullToRefresh } from "@/components/PullToRefresh";
 import ProgressTracker from "@/components/ProgressTracker";
+import { CommandPalette, buildCommandItems } from "@/components/CommandPalette";
 import { useDashboardData } from "@/hooks/useDashboardData";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+
+const themes = ["light", "dark", "system"] as const;
 
 export default function Home() {
   const { data, isLoading, error, connectionStatus, countdown, refresh } =
     useDashboardData();
   const [activeTab, setActiveTab] = useState<MobileTab>("agents");
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [paletteKey, setPaletteKey] = useState(0);
+  const { theme, setTheme } = useTheme();
 
   const prevAgentsRef = useRef<Map<string, string>>(new Map());
 
@@ -56,6 +64,44 @@ export default function Home() {
     }
     prevAgentsRef.current = next;
   }, [data]);
+
+  const cycleTheme = useCallback(() => {
+    const currentIndex = themes.indexOf(theme as (typeof themes)[number]);
+    const nextIndex = (currentIndex + 1) % themes.length;
+    setTheme(themes[nextIndex]);
+  }, [theme, setTheme]);
+
+  const scrollToSection = useCallback((id: string) => {
+    document.getElementById(`section-${id}`)?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  const openPalette = useCallback(() => {
+    setPaletteKey((k) => k + 1);
+    setPaletteOpen(true);
+  }, []);
+
+  const togglePalette = useCallback(() => {
+    setPaletteOpen((prev) => {
+      if (!prev) setPaletteKey((k) => k + 1);
+      return !prev;
+    });
+  }, []);
+
+  useKeyboardShortcuts({
+    onToggleCommandPalette: togglePalette,
+    onRefresh: refresh,
+    onToggleTheme: cycleTheme,
+  });
+
+  const commandItems = useMemo(
+    () =>
+      buildCommandItems(data, {
+        refresh,
+        toggleTheme: cycleTheme,
+        scrollToSection,
+      }),
+    [data, refresh, cycleTheme, scrollToSection],
+  );
 
   const stats = data
     ? [
@@ -106,6 +152,14 @@ export default function Home() {
     <main className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-white pb-[72px] md:pb-0">
       <ToastContainer />
 
+      {/* Command Palette */}
+      <CommandPalette
+        key={paletteKey}
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        items={commandItems}
+      />
+
       {/* Header */}
       <header className="sticky top-0 z-40 border-b border-gray-200 bg-white/80 dark:border-white/10 dark:bg-gray-900/80 backdrop-blur-sm">
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
@@ -118,6 +172,19 @@ export default function Home() {
             </h1>
           </div>
           <div className="flex items-center gap-3 sm:gap-4">
+            <button
+              onClick={openPalette}
+              className="hidden sm:flex items-center gap-2 rounded-lg border border-gray-200 dark:border-white/10 bg-gray-50 dark:bg-white/5 px-3 py-1.5 text-xs text-gray-500 dark:text-white/50 hover:bg-gray-100 dark:hover:bg-white/10 hover:text-gray-700 dark:hover:text-white/70 transition-colors"
+              data-testid="command-palette-trigger"
+            >
+              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+              <span>Search...</span>
+              <kbd className="rounded border border-gray-300 dark:border-white/20 px-1 py-0.5 text-[10px] font-medium">
+                ⌘K
+              </kbd>
+            </button>
             <ThemeToggle />
             <NotificationCenter />
             <ConnectionIndicator status={connectionStatus} />
@@ -171,6 +238,7 @@ export default function Home() {
           <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8 space-y-6">
             {/* Stats Bar - always visible */}
             <section
+              id="section-stats"
               aria-label="Dashboard statistics"
               className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6 stagger-children"
             >
@@ -198,10 +266,12 @@ export default function Home() {
             {/* Agents Tab */}
             <div className={activeTab !== "agents" ? "hidden md:block" : ""}>
               <div className="space-y-6">
-                <AgentStatusCards />
+                <div id="section-sessions">
+                  <AgentStatusCards />
+                </div>
 
                 {/* Agent Cards Grid */}
-                <section aria-label="Agent cards" className="animate-fade-in">
+                <section id="section-agents" aria-label="Agent cards" className="animate-fade-in">
                   <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
                     Agents
                   </h2>
@@ -230,7 +300,7 @@ export default function Home() {
                 <MergeQueue />
               </section>
 
-              <section aria-label="Recent PRs" className="mt-6">
+              <section id="section-prs" aria-label="Recent PRs" className="mt-6">
                 <RecentPRs />
               </section>
             </div>
@@ -242,7 +312,7 @@ export default function Home() {
                 <TokenUsageDashboard />
               </section>
 
-              <section aria-label="Activity log" className="mt-6">
+              <section id="section-activity" aria-label="Activity log" className="mt-6">
                 <ActivityLog events={activityEvents} maxHeight="max-h-[32rem]" />
               </section>
             </div>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { fuzzyMatch } from "@/lib/fuzzyMatch";
+import type { DashboardData } from "@/types/dashboard";
+
+export interface CommandItem {
+  id: string;
+  label: string;
+  category: "action" | "agent" | "pr" | "navigation";
+  shortcut?: string;
+  icon: string;
+  onSelect: () => void;
+}
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  items: CommandItem[];
+}
+
+/**
+ * Outer shell — renders nothing when closed. The inner component
+ * remounts each time via the `instanceKey` prop which the parent
+ * should increment on each open.
+ */
+export function CommandPalette({ open, onClose, items }: CommandPaletteProps) {
+  if (!open) return null;
+  return <CommandPaletteInner onClose={onClose} items={items} />;
+}
+
+const categoryLabels: Record<CommandItem["category"], string> = {
+  action: "Actions",
+  agent: "Agents",
+  pr: "Pull Requests",
+  navigation: "Navigation",
+};
+
+function CommandPaletteInner({
+  onClose,
+  items,
+}: {
+  onClose: () => void;
+  items: CommandItem[];
+}) {
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return items;
+    return items
+      .map((item) => {
+        const match = fuzzyMatch(query, item.label);
+        return match ? { item, score: match.score } : null;
+      })
+      .filter(Boolean)
+      .sort((a, b) => a!.score - b!.score)
+      .map((r) => r!.item);
+  }, [query, items]);
+
+  const updateQuery = useCallback((value: string) => {
+    setQuery(value);
+    setSelectedIndex(0);
+  }, []);
+
+  // Auto-focus input on mount
+  useEffect(() => {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const selected = list.children[selectedIndex] as HTMLElement | undefined;
+    selected?.scrollIntoView?.({ block: "nearest" });
+  }, [selectedIndex]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setSelectedIndex((i) => Math.max(i - 1, 0));
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (filtered[selectedIndex]) {
+            filtered[selectedIndex].onSelect();
+            onClose();
+          }
+          break;
+        case "Escape":
+          e.preventDefault();
+          onClose();
+          break;
+      }
+    },
+    [filtered, selectedIndex, onClose],
+  );
+
+  // Group items by category while preserving order
+  const grouped: { category: CommandItem["category"]; items: CommandItem[] }[] =
+    [];
+  const seen = new Set<string>();
+  for (const item of filtered) {
+    if (!seen.has(item.category)) {
+      seen.add(item.category);
+      grouped.push({
+        category: item.category,
+        items: filtered.filter((i) => i.category === item.category),
+      });
+    }
+  }
+
+  let runningIndex = 0;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+      data-testid="command-palette"
+    >
+      {/* Backdrop */}
+      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm" />
+
+      {/* Palette */}
+      <div
+        className="relative w-full max-w-lg rounded-xl border border-gray-200 bg-white shadow-2xl dark:border-white/10 dark:bg-gray-900 overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Search input */}
+        <div className="flex items-center gap-3 border-b border-gray-200 dark:border-white/10 px-4 py-3">
+          <svg
+            className="h-5 w-5 shrink-0 text-gray-400 dark:text-white/40"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => updateQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type a command or search..."
+            className="flex-1 bg-transparent text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-white/40 outline-none"
+            data-testid="command-palette-input"
+          />
+          <kbd className="hidden sm:inline-flex rounded border border-gray-200 dark:border-white/20 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-white/40">
+            ESC
+          </kbd>
+        </div>
+
+        {/* Results */}
+        <div
+          ref={listRef}
+          className="max-h-72 overflow-y-auto py-2"
+          role="listbox"
+          data-testid="command-palette-results"
+        >
+          {filtered.length === 0 ? (
+            <p className="px-4 py-8 text-center text-sm text-gray-500 dark:text-white/50">
+              No results found
+            </p>
+          ) : (
+            grouped.map((group) => {
+              const groupItems = group.items;
+              const startIndex = runningIndex;
+              runningIndex += groupItems.length;
+
+              return (
+                <div key={group.category}>
+                  <div className="px-4 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-white/30">
+                    {categoryLabels[group.category]}
+                  </div>
+                  {groupItems.map((item, i) => {
+                    const globalIndex = startIndex + i;
+                    const isSelected = globalIndex === selectedIndex;
+                    return (
+                      <button
+                        key={item.id}
+                        role="option"
+                        aria-selected={isSelected}
+                        className={`flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors ${
+                          isSelected
+                            ? "bg-blue-50 text-blue-600 dark:bg-blue-500/10 dark:text-blue-400"
+                            : "text-gray-700 dark:text-white/70 hover:bg-gray-50 dark:hover:bg-white/5"
+                        }`}
+                        onClick={() => {
+                          item.onSelect();
+                          onClose();
+                        }}
+                        onMouseEnter={() => setSelectedIndex(globalIndex)}
+                        data-testid={`command-item-${item.id}`}
+                      >
+                        <span className="text-base" aria-hidden="true">
+                          {item.icon}
+                        </span>
+                        <span className="flex-1 truncate">{item.label}</span>
+                        {item.shortcut && (
+                          <kbd className="rounded border border-gray-200 dark:border-white/20 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:text-white/40">
+                            {item.shortcut}
+                          </kbd>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center gap-4 border-t border-gray-200 dark:border-white/10 px-4 py-2 text-[10px] text-gray-400 dark:text-white/30">
+          <span>
+            <kbd className="font-medium">↑↓</kbd> navigate
+          </span>
+          <span>
+            <kbd className="font-medium">↵</kbd> select
+          </span>
+          <span>
+            <kbd className="font-medium">esc</kbd> close
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Builds the command items list from dashboard data and action handlers.
+ */
+export function buildCommandItems(
+  data: DashboardData | null,
+  actions: {
+    refresh: () => void;
+    toggleTheme: () => void;
+    scrollToSection: (id: string) => void;
+  },
+): CommandItem[] {
+  const items: CommandItem[] = [];
+
+  // Static actions
+  items.push({
+    id: "action-refresh",
+    label: "Refresh dashboard",
+    category: "action",
+    shortcut: "R",
+    icon: "↻",
+    onSelect: actions.refresh,
+  });
+  items.push({
+    id: "action-theme",
+    label: "Toggle theme",
+    category: "action",
+    shortcut: "T",
+    icon: "◑",
+    onSelect: actions.toggleTheme,
+  });
+
+  // Navigation
+  const sections = [
+    { id: "stats", label: "Go to Stats", icon: "📊" },
+    { id: "sessions", label: "Go to Agent Sessions", icon: "🖥" },
+    { id: "agents", label: "Go to Agents", icon: "🤖" },
+    { id: "prs", label: "Go to Recent PRs", icon: "🔀" },
+    { id: "activity", label: "Go to Activity Log", icon: "📋" },
+  ];
+  for (const section of sections) {
+    items.push({
+      id: `nav-${section.id}`,
+      label: section.label,
+      category: "navigation",
+      icon: section.icon,
+      onSelect: () => actions.scrollToSection(section.id),
+    });
+  }
+
+  if (!data) return items;
+
+  // Agent items
+  for (const agent of data.agents) {
+    items.push({
+      id: `agent-${agent.sessionId}`,
+      label: `${agent.name} — ${agent.issue.title}`,
+      category: "agent",
+      icon: agent.status === "error" ? "❌" : "🤖",
+      onSelect: () => {
+        if (agent.pr?.url) {
+          window.open(agent.pr.url, "_blank");
+        } else {
+          window.open(agent.issue.url, "_blank");
+        }
+      },
+    });
+  }
+
+  // PR items
+  for (const pr of data.prs) {
+    const statusIcon =
+      pr.mergeState === "merged"
+        ? "🟣"
+        : pr.ciStatus === "passing"
+          ? "🟢"
+          : pr.ciStatus === "failing"
+            ? "🔴"
+            : "🟡";
+    items.push({
+      id: `pr-${pr.number}`,
+      label: `#${pr.number} ${pr.title}`,
+      category: "pr",
+      icon: statusIcon,
+      onSelect: () => window.open(pr.url, "_blank"),
+    });
+  }
+
+  return items;
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+
+interface KeyboardShortcutHandlers {
+  onToggleCommandPalette: () => void;
+  onRefresh: () => void;
+  onToggleTheme: () => void;
+}
+
+export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const isInput =
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable;
+
+      // Cmd/Ctrl+K — always opens palette
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        handlers.onToggleCommandPalette();
+        return;
+      }
+
+      // Skip single-key shortcuts when typing in an input
+      if (isInput) return;
+
+      switch (e.key.toLowerCase()) {
+        case "r":
+          e.preventDefault();
+          handlers.onRefresh();
+          break;
+        case "t":
+          e.preventDefault();
+          handlers.onToggleTheme();
+          break;
+      }
+    },
+    [handlers],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+}

--- a/src/lib/fuzzyMatch.ts
+++ b/src/lib/fuzzyMatch.ts
@@ -1,0 +1,30 @@
+/**
+ * Simple fuzzy matching: checks if all characters in the query
+ * appear in order within the target string (case-insensitive).
+ * Returns a score (lower = better match) or null if no match.
+ */
+export function fuzzyMatch(
+  query: string,
+  target: string,
+): { score: number } | null {
+  const q = query.toLowerCase();
+  const t = target.toLowerCase();
+
+  if (q.length === 0) return { score: 0 };
+
+  let qi = 0;
+  let score = 0;
+  let lastMatchIndex = -1;
+
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      // Bonus for consecutive matches
+      score += ti === lastMatchIndex + 1 ? 0 : ti - (lastMatchIndex + 1);
+      lastMatchIndex = ti;
+      qi++;
+    }
+  }
+
+  if (qi < q.length) return null; // not all characters matched
+  return { score };
+}


### PR DESCRIPTION
## Summary
- Adds a command palette (Cmd/Ctrl+K) with fuzzy search across actions, agents, PRs, and page sections
- Global keyboard shortcuts: `R` to refresh, `T` to toggle theme (suppressed when typing in inputs)
- Navigation commands to scroll to dashboard sections (Stats, Sessions, Agents, PRs, Activity Log)
- Agent/PR items link directly to their GitHub URLs

## New Files
- `src/components/CommandPalette.tsx` — palette UI with fuzzy-filtered, categorized results
- `src/hooks/useKeyboardShortcuts.ts` — global keydown listener for Cmd/Ctrl+K, R, T
- `src/lib/fuzzyMatch.ts` — lightweight fuzzy string matching with scoring
- `src/__tests__/CommandPalette.test.tsx` — 15 tests for palette rendering, search, keyboard nav
- `src/__tests__/useKeyboardShortcuts.test.ts` — 6 tests for shortcut behavior
- `src/__tests__/fuzzyMatch.test.ts` — 6 tests for matching logic

## Modified Files
- `src/app/page.tsx` — integrates palette, adds section IDs, header search trigger button

## Test plan
- [x] `npm run build` passes with no lint errors
- [x] All 210 tests pass (22 test files)
- [ ] Manual: open palette with Cmd/Ctrl+K, verify fuzzy search filters items
- [ ] Manual: press R to refresh, T to toggle theme
- [ ] Manual: verify shortcuts are suppressed when focused on an input field
- [ ] Manual: navigate palette with arrow keys, select with Enter, close with Escape

Closes #44