### PR TITLE
feat: add empty state illustrations for agent sessions and activity

### DIFF
--- a/src/__tests__/ActivityLog.test.tsx
+++ b/src/__tests__/ActivityLog.test.tsx
@@ -52,7 +52,9 @@ describe("ActivityLog", () => {
 
   it("shows empty state when no events", () => {
     render(<ActivityLog events={[]} />);
-    expect(screen.getByText("No events to display.")).toBeInTheDocument();
+    expect(screen.getByText("No recent activity")).toBeInTheDocument();
+    expect(screen.getByText("Events from your agents will appear here as they work.")).toBeInTheDocument();
+    expect(screen.getByTestId("empty-state")).toBeInTheDocument();
   });
 
   it("renders all events", () => {

--- a/src/__tests__/EmptyState.test.tsx
+++ b/src/__tests__/EmptyState.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import EmptyState from "@/components/EmptyState";
+
+describe("EmptyState", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders title and description", () => {
+    render(<EmptyState title="No data" description="Nothing to show here." />);
+    expect(screen.getByText("No data")).toBeInTheDocument();
+    expect(screen.getByText("Nothing to show here.")).toBeInTheDocument();
+  });
+
+  it("renders with data-testid", () => {
+    render(<EmptyState title="Empty" description="Desc" />);
+    expect(screen.getByTestId("empty-state")).toBeInTheDocument();
+  });
+
+  it("renders default icon when none provided", () => {
+    render(<EmptyState title="Empty" description="Desc" />);
+    const svg = screen.getByTestId("empty-state").querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("renders custom icon when provided", () => {
+    render(
+      <EmptyState
+        icon={<span data-testid="custom-icon">Custom</span>}
+        title="Empty"
+        description="Desc"
+      />
+    );
+    expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+  });
+
+  it("renders ReactNode description", () => {
+    render(
+      <EmptyState
+        title="Empty"
+        description={<span data-testid="rich-desc">Rich description</span>}
+      />
+    );
+    expect(screen.getByTestId("rich-desc")).toBeInTheDocument();
+  });
+
+  it("uses theme-aware classes", () => {
+    render(<EmptyState title="Empty" description="Desc" />);
+    const container = screen.getByTestId("empty-state");
+    expect(container.className).toContain("dark:border-white/10");
+    expect(container.className).toContain("dark:bg-white/5");
+  });
+});

--- a/src/components/ActivityLog.tsx
+++ b/src/components/ActivityLog.tsx
@@ -1,3 +1,5 @@
+import EmptyState from "@/components/EmptyState";
+
 export type EventType = "commit" | "pr_created" | "ci_failed" | "ci_passed" | "review" | "deploy" | "error";
 
 export interface AgentEvent {
@@ -72,7 +74,15 @@ export default function ActivityLog({ events, maxHeight = "max-h-96" }: Activity
       <h2 className="mb-3 text-lg font-semibold text-gray-900 dark:text-gray-100">Activity Log</h2>
       <div className={`${maxHeight} overflow-y-auto pr-1`} data-testid="activity-log-scroll">
         {sorted.length === 0 ? (
-          <p className="py-4 text-center text-sm text-gray-500 dark:text-gray-400">No events to display.</p>
+          <EmptyState
+            icon={
+              <svg className="h-6 w-6 text-gray-400 dark:text-white/40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5} aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            }
+            title="No recent activity"
+            description="Events from your agents will appear here as they work."
+          />
         ) : (
           <ul className="space-y-2" role="list">
             {sorted.map((event, index) => {

--- a/src/components/AgentStatusCards.tsx
+++ b/src/components/AgentStatusCards.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import type { TmuxSession, SessionsResponse } from "@/types/sessions";
 import TerminalViewer from "@/components/TerminalViewer";
+import EmptyState from "@/components/EmptyState";
 
 const STATUS_CONFIG = {
   working: {
@@ -130,17 +131,18 @@ export default function AgentStatusCards() {
         <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
           Agent Sessions
         </h2>
-        <div
-          data-testid="sessions-empty"
-          className="rounded-xl border border-gray-200 bg-white px-4 py-8 text-center dark:border-white/10 dark:bg-white/5"
-        >
-          <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-gray-100 dark:bg-white/10">
-            <svg className="h-6 w-6 text-gray-400 dark:text-white/40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h9a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0015.75 4.5h-9A2.25 2.25 0 004.5 6.75v10.5A2.25 2.25 0 006.75 19.5z" />
-            </svg>
-          </div>
-          <p className="text-sm font-medium text-gray-900 dark:text-white">No active agents</p>
-          <p className="mt-1 text-xs text-gray-500 dark:text-white/50">Create issues with the <code className="rounded bg-gray-100 dark:bg-white/10 px-1 py-0.5 font-mono text-xs">agent-local</code> label to start work</p>
+        <div data-testid="sessions-empty">
+          <EmptyState
+            icon={
+              <svg className="h-6 w-6 text-gray-400 dark:text-white/40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 3v1.5M4.5 8.25H3m18 0h-1.5M4.5 12H3m18 0h-1.5m-15 3.75H3m18 0h-1.5M8.25 19.5V21M12 3v1.5m0 15V21m3.75-18v1.5m0 15V21m-9-1.5h9a2.25 2.25 0 002.25-2.25V6.75A2.25 2.25 0 0015.75 4.5h-9A2.25 2.25 0 004.5 6.75v10.5A2.25 2.25 0 006.75 19.5z" />
+              </svg>
+            }
+            title="No active agents"
+            description={
+              <>Create issues with the <code className="rounded bg-gray-100 dark:bg-white/10 px-1 py-0.5 font-mono text-xs">agent-local</code> label to start work</>
+            }
+          />
         </div>
       </section>
     );

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+
+interface EmptyStateProps {
+  icon?: ReactNode;
+  title: string;
+  description: string | ReactNode;
+}
+
+function DefaultIcon() {
+  return (
+    <svg
+      className="h-6 w-6 text-gray-400 dark:text-white/40"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
+      />
+    </svg>
+  );
+}
+
+export default function EmptyState({ icon, title, description }: EmptyStateProps) {
+  return (
+    <div
+      data-testid="empty-state"
+      className="rounded-xl border border-gray-200 bg-white px-4 py-8 text-center dark:border-white/10 dark:bg-white/5"
+    >
+      <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-gray-100 dark:bg-white/10">
+        {icon ?? <DefaultIcon />}
+      </div>
+      <p className="text-sm font-medium text-gray-900 dark:text-white">{title}</p>
+      <p className="mt-1 text-xs text-gray-500 dark:text-white/50">{description}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #108